### PR TITLE
generated schema and tests for v1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.ipk_gatersleben.bit.bi.bridge.brapicomp</groupId>
@@ -10,8 +11,8 @@
 	<properties>
 		<tomcat7-maven-plugin.version>2.2</tomcat7-maven-plugin.version>
 		<webappHome>src/main/webapp</webappHome>
-        <buildDate>${maven.build.timestamp}</buildDate>
-        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+		<buildDate>${maven.build.timestamp}</buildDate>
+		<maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 	</properties>
 
 	<build>
@@ -20,34 +21,34 @@
 		<sourceDirectory>src/main/java</sourceDirectory>
 		<plugins>
 
-            <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.4</version>
-                <executions>
-                    <execution>
-                        <id>get-the-git-infos</id>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                    </execution>
-                </executions>
+			<plugin>
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.2.4</version>
+				<executions>
+					<execution>
+						<id>get-the-git-infos</id>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
 
-                <configuration>
-                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                    <prefix>git</prefix>
-                    <verbose>false</verbose>
-                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                    <format>json</format>
-                    <gitDescribe>
-                        <skip>false</skip>
-                        <always>false</always>
-                        <dirty>-dirty</dirty>
-                    </gitDescribe>
-                </configuration>
+				<configuration>
+					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+					<prefix>git</prefix>
+					<verbose>false</verbose>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+					<format>json</format>
+					<gitDescribe>
+						<skip>false</skip>
+						<always>false</always>
+						<dirty>-dirty</dirty>
+					</gitDescribe>
+				</configuration>
 
-            </plugin>
+			</plugin>
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -61,18 +62,18 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
-                    <webResources>
-                        <resource>
-                            <directory>src/main/resources/schemas</directory>
-                            <targetPath>schemas</targetPath>
-                        </resource>
-                        <resource>
-                            <filtering>true</filtering>
-                            <directory>src/main/webapp/advanced</directory>
-                            <includes>
-                                <include>**/index.html</include>
-                            </includes>
-                        </resource>
+					<webResources>
+						<resource>
+							<directory>src/main/resources/schemas</directory>
+							<targetPath>schemas</targetPath>
+						</resource>
+						<resource>
+							<filtering>true</filtering>
+							<directory>src/main/webapp/advanced</directory>
+							<includes>
+								<include>**/index.html</include>
+							</includes>
+						</resource>
 					</webResources>
 					<warSourceDirectory>${webappHome}/advanced</warSourceDirectory>
 					<failOnMissingWebXml>true</failOnMissingWebXml>
@@ -81,7 +82,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.3.14.v20161028</version>
+				<version>9.3.24.v20180605</version>
 				<configuration>
 					<scanIntervalSeconds>1</scanIntervalSeconds>
 					<scanTargetPatterns>
@@ -157,17 +158,17 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.3.14.v20161028</version>
+			<version>9.3.24.v20180605</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>9.3.14.v20161028</version>
+			<version>9.3.24.v20180605</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlets</artifactId>
-			<version>9.3.14.v20161028</version>
+			<version>9.3.24.v20180605</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>
@@ -201,41 +202,41 @@
 			<version>12.1.0.1</version>
 		</dependency>
 		<dependency>
-		    <groupId>com.github.fge</groupId>
-		    <artifactId>json-schema-validator</artifactId>
-		    <version>2.2.6</version>
-		    <exclusions>
-		    	<exclusion>
-		    		<groupId>javax.mail</groupId>
-		    		<artifactId>mailapi</artifactId>
-		    	</exclusion>
-		    </exclusions>
+			<groupId>com.github.fge</groupId>
+			<artifactId>json-schema-validator</artifactId>
+			<version>2.2.6</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.mail</groupId>
+					<artifactId>mailapi</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-lang3</artifactId>
-		    <version>3.4</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
 		</dependency>
 		<dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.5.4</version>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>javax.mail</artifactId>
+			<version>1.5.4</version>
 		</dependency>
 		<dependency>
-	      <groupId>org.quartz-scheduler</groupId>
-	      <artifactId>quartz</artifactId>
-	      <version>2.2.1</version>
-	    </dependency>
-	    <dependency>
-	      <groupId>org.quartz-scheduler</groupId>
-	      <artifactId>quartz-jobs</artifactId>
-	      <version>2.2.1</version>
-	    </dependency>
-	    <dependency>
-	      <groupId>junit</groupId>
-	      <artifactId>junit</artifactId>
-	      <version>4.12</version>
-	      <scope>test</scope>
-	    </dependency>
+			<groupId>org.quartz-scheduler</groupId>
+			<artifactId>quartz</artifactId>
+			<version>2.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.quartz-scheduler</groupId>
+			<artifactId>quartz-jobs</artifactId>
+			<version>2.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CallTestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CallTestSuiteRunner.java
@@ -30,13 +30,14 @@ public class CallTestSuiteRunner implements TestSuiteRunner {
 
     /**
      * Run the tests
+     * @param singleTest 
      *
      * @return Test report
      */
-    public TestSuiteReport runTests(boolean allowAdditional) {
+    public TestSuiteReport runTests(boolean allowAdditional, Boolean singleTest) {
         TestSuiteReport testSuiteReport = new TestSuiteReport(id, url);
         TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, url);
-        TestCollectionReport tcr = testCollectionRunner.runTestsFromCall(allowAdditional);
+        TestCollectionReport tcr = testCollectionRunner.runTestsFromCall(allowAdditional, singleTest);
         testSuiteReport.addTestCollectionReport(tcr);
         return testSuiteReport;
     }

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CustomTestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CustomTestSuiteRunner.java
@@ -33,7 +33,7 @@ public class CustomTestSuiteRunner implements TestSuiteRunner {
      *
      * @return Test report
      */
-    public TestSuiteReport runTests(boolean allowAdditional) {
+    public TestSuiteReport runTests(boolean allowAdditional, Boolean singleTest) {
         TestSuiteReport testSuiteReport = new TestSuiteReport(id, url);
         TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, url);
         TestCollectionReport tcr = testCollectionRunner.runTests(allowAdditional);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestCollectionRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestCollectionRunner.java
@@ -48,7 +48,7 @@ public class TestCollectionRunner {
         return tcr;
     }
 
-	public TestCollectionReport runTestsFromCall(boolean allowAdditional) {
+	public TestCollectionReport runTestsFromCall(boolean allowAdditional, Boolean singleTest) {
         String name = testCollection.getInfo().getName();
         TestCollectionReport tcr = new TestCollectionReport(name, url);
         String baseUrl = url.replaceAll("/$", "");
@@ -62,9 +62,9 @@ public class TestCollectionRunner {
             TestFolderRunner tfr = new TestFolderRunner(baseUrl, folderList.get(i), storage);
             TestFolderReport tfReport;
             if (i == 0) {
-            	tfReport = tfr.runTests(doneTests, allowAdditional);
+            	tfReport = tfr.runTests(doneTests, allowAdditional, singleTest);
             } else {
-            	tfReport = tfr.runTestsFromCall(doneTests, allowAdditional);
+            	tfReport = tfr.runTestsFromCall(doneTests, allowAdditional, singleTest);
             }
            
             tcr.addFolder(tfReport);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestFolderRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestFolderRunner.java
@@ -39,7 +39,7 @@ public class TestFolderRunner {
      *
      * @return Test report.
      */
-    public TestFolderReport runTests(List<String> doneTests, boolean allowAdditional) {
+    public TestFolderReport runTests(List<String> doneTests, boolean allowAdditional, Boolean singleTest) {
         TestFolderReport tcr = new TestFolderReport(this.baseUrl);
         tcr.setName(this.folder.getName());
         tcr.setDescription(this.folder.getDescription());
@@ -47,7 +47,7 @@ public class TestFolderRunner {
         LinkedHashMap<String, Object> folderTests = new LinkedHashMap<String, Object>();
         itemList.forEach(item -> {
             TestItemRunner tir = new TestItemRunner(item, storage);
-            TestItemReport tiReport = tir.runTests(allowAdditional);
+            TestItemReport tiReport = tir.runTests(allowAdditional, singleTest);
             tcr.addTestReport(tiReport);
             doneTests.add(item.getName());
             folderTests.put(item.getName(), tiReport);
@@ -63,10 +63,10 @@ public class TestFolderRunner {
      * @return Test report.
      */
     public TestFolderReport runTests(boolean allowAdditional) {
-    	return runTests(new ArrayList<String>(), allowAdditional);
+    	return runTests(new ArrayList<String>(), allowAdditional, false);
     }
 
-	public TestFolderReport runTestsFromCall(List<String> doneTests, boolean allowAdditional) {
+	public TestFolderReport runTestsFromCall(List<String> doneTests, boolean allowAdditional, Boolean singleTest) {
         TestFolderReport tcr = new TestFolderReport(this.baseUrl);
         tcr.setName(this.folder.getName());
         tcr.setDescription(this.folder.getDescription());        
@@ -90,7 +90,7 @@ public class TestFolderRunner {
         		    		
         		if (storage.getKeys().containsAll(item.getRequires())) {
         			TestItemRunner tir = new TestItemRunner(item, storage);
-            		TestItemReport tiReport = tir.runTests(allowAdditional);
+            		TestItemReport tiReport = tir.runTests(allowAdditional, singleTest);
                     tcr.addTestReport(tiReport);
                     doneTests.add(item.getName());
                     folderTests.put(item.getName(), tiReport);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestItemRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestItemRunner.java
@@ -71,12 +71,13 @@ public class TestItemRunner {
 
     /**
      * Run the tests
+     * @param singleTest 
      *
      * @return Report
      */
-    public TestItemReport runTests(boolean allowAdditional) {
+    public TestItemReport runTests(boolean allowAdditional, Boolean singleTest) {
     	
-        this.vr = connect();
+        this.vr = connect(singleTest);
         
         //TODO: Only first event in Item.event is executed.
         List<String> execList = this.item.getEvent().get(0).getExec();
@@ -214,19 +215,22 @@ public class TestItemRunner {
 
     /**
      * Connect to an endpoint and store the server response.
+     * @param singleTest 
      *
      * @return server response
      */
-    private ValidatableResponse connect() {
+    private ValidatableResponse connect(Boolean singleTest) {
         LOGGER.info("New Request. URL: " + this.url);
         
         RestAssured.useRelaxedHTTPSValidation();
         try {
         	URL u = new URL(url);
-    		if ((Config.get("advancedMode") != null && Config.get("advancedMode").equals("true"))
-    			&& u.getPort() != 80 && u.getPort() != -1) {
-				throw new IllegalArgumentException();
-			}
+        	if(singleTest == null || !singleTest) { // singleTest indicates this came from a manual web submission and should not be restricted by port
+	    		if ((Config.get("advancedMode") != null && Config.get("advancedMode").equals("true"))
+	    			&& u.getPort() != 80 && u.getPort() != -1) {
+					throw new IllegalArgumentException();
+				}
+        	}
             RequestSpecification rs = given()
             		.contentType("application/json");
 			List<Param> params = this.item.getParameters();

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestSuiteRunner.java
@@ -10,7 +10,7 @@ public interface TestSuiteRunner {
      *
      * @return Test report
      */
-    public TestSuiteReport runTests(boolean allowAdditional);
+    public TestSuiteReport runTests(boolean allowAdditional, Boolean singleTest);
 
     /**
      * @return the id

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/utils/RunnerService.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/utils/RunnerService.java
@@ -38,7 +38,7 @@ public class RunnerService {
             id = ep.getId().toString();
         }
         CustomTestSuiteRunner t = new CustomTestSuiteRunner(id, ep.getUrl(), testCollection);
-        return t.runTests(allowAdditional);
+        return t.runTests(allowAdditional, false);
     }
     
     /**
@@ -46,15 +46,16 @@ public class RunnerService {
      *
      * @param ep             Resource to be tested
      * @param tc 
+     * @param singleTest 
      * @return Report
      */
-	public static TestSuiteReport testEndpointWithCall(Resource ep, TestCollection tc, boolean allowAdditional) {
+	public static TestSuiteReport testEndpointWithCall(Resource ep, TestCollection tc, boolean allowAdditional, Boolean singleTest) {
         String id = "";
         if (ep.getId() != null) {
             id = ep.getId().toString();
         }
         CallTestSuiteRunner t = new CallTestSuiteRunner(id, ep.getUrl(), tc);
-        return t.runTests(allowAdditional);
+        return t.runTests(allowAdditional, singleTest);
     }
 
     /**
@@ -72,7 +73,7 @@ public class RunnerService {
         boolean sent;
         for (int i = 0; i < l.size(); i++) {
             Resource resource = l.get(i);
-            TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(resource, testCollection, allowAdditional);
+            TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(resource, testCollection, allowAdditional, false);
             
             final int N = resource.getStoreprev();
             // Get last N reports
@@ -133,7 +134,7 @@ public class RunnerService {
      */
     public static TestItemReport singleTestEndpoint(Item simple, boolean allowAdditional) {
         TestItemRunner tir = new TestItemRunner(simple);
-        return tir.runTests(allowAdditional);
+        return tir.runTests(allowAdditional, false);
     }
 
     /**
@@ -145,7 +146,7 @@ public class RunnerService {
      */
     public static TestItemReport singleTestEndpoint(Item simple, VariableStorage storage, boolean allowAdditional) {
         TestItemRunner tir = new TestItemRunner(simple, storage);
-        return tir.runTests(allowAdditional);
+        return tir.runTests(allowAdditional, false);
     }
 
 	public static void TestAllPublicEndpoints(TestCollection tc, boolean allowAdditional) throws SQLException {
@@ -153,7 +154,7 @@ public class RunnerService {
 		LOGGER.info("Endpoints found: " + l.size());
 		for (int i = 0; i < l.size(); i++) {
 			Resource resource = l.get(i);
-            TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(resource, tc, allowAdditional);
+            TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(resource, tc, allowAdditional, false);
             
             ObjectMapper mapper = new ObjectMapper();
             try {
@@ -169,7 +170,7 @@ public class RunnerService {
 
 	public static void TestEndpointWithCallAndSaveReport(Resource res, TestCollection tc, boolean allowAdditional) throws JsonProcessingException, SQLException {
 		ObjectMapper mapper = new ObjectMapper();
-		TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(res, tc, allowAdditional);
+		TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(res, tc, allowAdditional, false);
         TestReport report = new TestReport(res, mapper.writeValueAsString(testSuiteReport));
         String reportId = TestReportService.saveReport(report);
         testSuiteReport.setId(reportId);

--- a/src/main/resources/collections/CompleteBrapiTest.v1.3.json
+++ b/src/main/resources/collections/CompleteBrapiTest.v1.3.json
@@ -1,0 +1,3104 @@
+{
+    "info": {
+        "description": "Includes all resources, schema and data",
+        "name": "Complete BrAPI test",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+    },
+    "item": [
+        {
+            "description": "Check the available calls on a server",
+            "item": [
+                {
+                    "description": " Implementation Notes\nHaving a consistent structure for the path string of each call is very important for teams to be able to connect and find errors. Read more on Github.\nHere are the rules for the path of each call that should be returned\n\n\n\nEvery word in the call path should match the documentation exactly, both in spelling and capitalization. Note that path strings are all lower case, but path parameters are camel case.\n\nEach path should start relative to \"/\" and therefore should not include \"/\"\n\nNo leading or trailing slashes (\"/\") \n\nPath parameters are wrapped in curly braces (\"{}\"). The name of the path parameter should be spelled exactly as it is specified in the documentation.\n\n\n\n\nExamples GOOD    \"call\": \"germplasm/{germplasmDbId}/markerprofiles\" BAD    \"call\": \"germplasm/{id}/markerprofiles\" BAD    \"call\": \"germplasm/{germplasmDbId}/markerProfiles\" BAD    \"call\": \"germplasm/{germplasmdbid}/markerprofiles\" BAD    \"call\": \"brapi/v1/germplasm/{germplasmDbId}/markerprofiles\" BAD    \"call\": \"/germplasm/{germplasmDbId}/markerprofiles/\" BAD    \"call\": \"germplasm/<germplasmDbId>/markerprofiles\"\n\n\n\ntest-server.brapi.org/brapi/v1/calls",
+                    "endpoint": "/calls",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Calls/getCallsResponse",
+                                "SaveCalls"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /calls",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/calls"
+                    },
+                    "requires": []
+                }
+            ],
+            "name": "Calls"
+        },
+        {
+            "description": "Information about Crops",
+            "item": [
+                {
+                    "description": "List the common crop names for the crops available in a database server. \n\nThis call is **required** for multi-crop systems where data from multiple crops may be stored in the same database server. A distinct database server is defined by everything in the URL before \"/brapi/v1\", including host name and base path.  \n\nThis call is recommended for single crop systems to be compatible with multi-crop clients. For a single crop system the response should contain an array with exactly 1 element. \n\nThe common crop name can be used as a search parameter for Programs, Studies, and Germplasm.\n\n\ntest-server.brapi.org/brapi/v1/commonCropNames",
+                    "endpoint": "/commoncropnames",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Crops/getCommoncropnamesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /commoncropnames",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/commoncropnames"
+                    },
+                    "requires": []
+                }
+            ],
+            "name": "Crops"
+        },
+        {
+            "description": "Information about Programs",
+            "item": [
+                {
+                    "description": "Call to retrieve a list of programs.",
+                    "endpoint": "/programs",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Programs/getProgramsResponse",
+                                "GetValue:/result/data/0/programDbId:programDbId0",
+                                "GetValue:/result/data/1/programDbId:programDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /programs",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/programs"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Advanced searching for the programs resource.\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/programs",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Programs/postSearchProgramsResponse",
+                                "GetValue:/result/searchResultDbId:programsSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/programs",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/programs"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Advanced searching for the programs resource.\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/programs/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Programs/getSearchProgramsSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/programs/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/programs/{programsSearchResultDbId}"
+                    },
+                    "requires": [
+                        "programsSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Programs"
+        },
+        {
+            "description": "Information about Locations",
+            "item": [
+                {
+                    "description": "Implemented by: Germinate\n\nGet a list of locations.\n\n* The `countryCode` is as per [ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec.\n\n* `altitude` is in meters.\n\n**Note**: Consider revising to describe polygon lat/lan points and check if adopting http://geojson.org/ is worth doing for v1.",
+                    "endpoint": "/locations",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Locations/getLocationsResponse",
+                                "GetValue:/result/data/0/locationDbId:locationDbId0",
+                                "GetValue:/result/data/1/locationDbId:locationDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /locations",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/locations"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get details for a location.\n\n- The `countryCode` is as per [ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec.\n\n- `altitude` is in meters.",
+                    "endpoint": "/locations/{locationDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Locations/getLocationsLocationdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /locations/{locationDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/locations/{locationDbId0}"
+                    },
+                    "requires": [
+                        "locationDbId0"
+                    ]
+                },
+                {
+                    "description": "Get details for a location.\n\n- The `countryCode` is as per [ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec.\n\n- `altitude` is in meters.",
+                    "endpoint": "/locations/{locationDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Locations/getLocationsLocationdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /locations/{locationDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/locations/{locationDbId1}"
+                    },
+                    "requires": [
+                        "locationDbId1"
+                    ]
+                }
+            ],
+            "name": "Locations"
+        },
+        {
+            "description": "Information about Trials",
+            "item": [
+                {
+                    "description": "Retrieve a filtered list of Trials. A Trial is a collection of studies",
+                    "endpoint": "/trials",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Trials/getTrialsResponse",
+                                "GetValue:/result/data/0/trialDbId:trialDbId0",
+                                "GetValue:/result/data/1/trialDbId:trialDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /trials",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/trials"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get trial by id.",
+                    "endpoint": "/trials/{trialDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Trials/getTrialsTrialdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /trials/{trialDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/trials/{trialDbId0}"
+                    },
+                    "requires": [
+                        "trialDbId0"
+                    ]
+                },
+                {
+                    "description": "Get trial by id.",
+                    "endpoint": "/trials/{trialDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Trials/getTrialsTrialdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /trials/{trialDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/trials/{trialDbId1}"
+                    },
+                    "requires": [
+                        "trialDbId1"
+                    ]
+                }
+            ],
+            "name": "Trials"
+        },
+        {
+            "description": "Information about Studies",
+            "item": [
+                {
+                    "description": "Get list of studies\nStartDate and endDate should be ISO8601 format for dates\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/studies",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/postSearchStudiesResponse",
+                                "GetValue:/result/searchResultDbId:studiesSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/studies",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/studies"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get list of studies\n\nStartDate and endDate should be ISO8601 format for dates\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/studies/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getSearchStudiesSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/studies/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/studies/{studiesSearchResultDbId}"
+                    },
+                    "requires": [
+                        "studiesSearchResultDbId"
+                    ]
+                },
+                {
+                    "description": "Call to retrive all seasons in the database.\n\nA season is made of 2 parts\n\n- The primary year \n\n- A term which defines a segment of the year. \nThis could be a traditional season, like \"Spring\" or \"Summer\"; \nthis could be a month, like \"May\" or \"June\"; \nor this could be an arbitrary season name which is meaningful to the breeding program like \"PlantingTime_3\" or \"Season E\"",
+                    "endpoint": "/seasons",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getSeasonsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /seasons",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/seasons"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get list of studies\n\nImplementation Notes\n\nStartDate and endDate should be ISO8601 format for dates\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/studies",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesResponse",
+                                "GetValue:/result/data/0/studyDbId:studyDbId0",
+                                "GetValue:/result/data/1/studyDbId:studyDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve the information of the study required for field data collection\n\nAn additionalInfo field was added to provide a controlled vocabulary for less common data fields.\n\nLinked data\n\n- Observation Variables: ```/brapi/v1/studies/{studyDbId}/observationvariables``` \n\n- Germplasm: ```/brapi/v1/studies/{studyDbId}/germplasm``` \n\n- Observation Units: ```/brapi/v1/studies/{studyDbId}/observationunits``` \n\n- Layout: ```brapi/v1/studies/{studyDbId}/layout```",
+                    "endpoint": "/studies/{studyDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the information of the study required for field data collection\n\nAn additionalInfo field was added to provide a controlled vocabulary for less common data fields.\n\nLinked data\n\n- Observation Variables: ```/brapi/v1/studies/{studyDbId}/observationvariables``` \n\n- Germplasm: ```/brapi/v1/studies/{studyDbId}/germplasm``` \n\n- Observation Units: ```/brapi/v1/studies/{studyDbId}/observationunits``` \n\n- Layout: ```brapi/v1/studies/{studyDbId}/layout```",
+                    "endpoint": "/studies/{studyDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId1}"
+                    },
+                    "requires": [
+                        "studyDbId1"
+                    ]
+                },
+                {
+                    "description": "Get the available Germplasm which are associated with this study",
+                    "endpoint": "/studies/{studyDbId}/germplasm",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidGermplasmResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/germplasm",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/germplasm"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrive the layout details for a study. Returns an array of observation unit position data which describes where each unit and germplasm is located within the study layout\n\nRetrieve the plot layout of the study with id {id}.\n\nFor each observationUnit within a study, return the `block`, `replicate`, and `entryType` values as well as the `X` and `Y` coordinates. `entryType` can be \"check\", \"test\", or \"filler\".\n\nAlso return some human readable meta data about the observationUnit and germplasm.",
+                    "endpoint": "/studies/{studyDbId}/layouts",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidLayoutsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/layouts",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/layouts"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Modify a study layout\n\nUpdate the layout data for a set of observation units within a study. Each layout object is a subset of fields within an observationUnit, so it doesnt make sense to create a new layout object by itself.\n\nImplementation Notes:\n\n+ If any of the fields in the request object is missing, that piece of data will not be updated. \n\n+ If an observationUnitDbId can not be found within the given study, an error will be returned. \n\n+ `entryType` can have the values \"check\", \"test\", or \"filler\". \n\n+ The response should match the structure of the response from `GET studies/{studyDbId}/layout`, but it should only contain the layout objects which have been updated by the PUT request. Also, pagination is not available in the response.",
+                    "endpoint": "/studies/{studyDbId}/layouts",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/putStudiesStudydbidLayoutsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /studies/{studyDbId}/layouts",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/studies/{studyDbId0}/layouts"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve all observations where there are measurements for the given observation variables.\n\nobservationTimestamp should be ISO8601 format with timezone -> YYYY-MM-DDThh:mm:ss+hhmm",
+                    "endpoint": "/studies/{studyDbId}/observations",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidObservationsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/observations",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/observations"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Implementation Guidelines: \n\n+ If an `observationDbId` is \"null\" or an empty string in the request, a NEW observation should be created for the given study and observationUnit \n\n+ If an `observationDbId` is populated but not found in the database, a NEW observation should be created for the given study and observationUnit AND an NEW `observationDbId` should be assigned to it. A warning should be returned to the client. \n\n+ If an `observationDbId` is populated and found in the database, but the existing entry is not associated with the given study or observationUnit, a NEW observation should be created for the given study and observationUnit AND an NEW `observationDbId` should be assigned to it. A warning should be returned to the client. \n\n+ If an `observationDbId` is populated and found in the database and is associated with the given study and observationUnit, then it should be updated with the new data given.",
+                    "endpoint": "/studies/{studyDbId}/observations",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/putStudiesStudydbidObservationsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /studies/{studyDbId}/observations",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/studies/{studyDbId0}/observations"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "The main API call for field data collection, to retrieve all the observation units within a study.",
+                    "endpoint": "/studies/{studyDbId}/observationunits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidObservationunitsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/observationunits",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/observationunits"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Use this call for uploading new Observations as JSON to a system.\n\nNote: If ''observationUnitDbId'' or ''observationDbId'' is populated, they should be considered updates to existing records. \nIf an existing record of that DbId is not found, the document should be treated as new records and assigned new DbIds. \nIf ''observationUnitDbId'' or ''observationDbId'' is un-populated (empty string or null) the document should be treated as new records and assigned new DbIds.",
+                    "endpoint": "/studies/{studyDbId}/observationunits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/putStudiesStudydbidObservationunitsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /studies/{studyDbId}/observationunits",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/studies/{studyDbId0}/observationunits"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "If ''observationUnitDbId'' or ''observationDbId'' is populated, they should be considered updates to existing records. \n\nIf an existing record of that DbId is not found, the document should be treated as new records and assigned new DbIds. \n\nIf ''observationUnitDbId'' or ''observationDbId'' is un-populated (empty string or null) the document should be treated as new records and assigned new DbIds.",
+                    "endpoint": "/studies/{studyDbId}/observationunits/zip",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/postStudiesStudydbidObservationunitsZipResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /studies/{studyDbId}/observationunits/zip",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/studies/{studyDbId0}/observationunits/zip"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "List all the observation variables measured in the study.\n\nRefer to the data type definition of variables in `/Specification/ObservationVariables/README.md`.",
+                    "endpoint": "/studies/{studyDbId}/observationvariables",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidObservationvariablesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/observationvariables",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/observationvariables"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the details of the study required for field data collection. Includes actual trait data.",
+                    "endpoint": "/studies/{studyDbId}/table",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudiesStudydbidTableResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studies/{studyDbId}/table",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studies/{studyDbId0}/table"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "This call can be used to create new observations in bulk.\n\nNote: If you need to update any existing observation, please use `PUT /studies/{studyDbId}/observations`. This call should only be used to create NEW observations.\n\nImplementation Guidelines:\n\n+ All observations submitted through this call should create NEW observation records in the database under the given observation unit. \n\n+ Each \"observationUnitDbId\" listed should already exist in the database. If the server can not find a given \"observationUnitDbId\", it should report an error. (see Error Handling) \n\n+ The response of this call should be the set of \"observationDbIds\" created from this call, along with the associated \"observationUnitDbId\" and \"observationVariableDbId\" that each observation is associated with.\n\n+ Images can optionally be saved using this call by providing a zipped file of all images in the datafiles. The physical zipped file should be transferred as well in the mulit-part form data.",
+                    "endpoint": "/studies/{studyDbId}/table",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/postStudiesStudydbidTableResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /studies/{studyDbId}/table",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/studies/{studyDbId0}/table"
+                    },
+                    "requires": [
+                        "studyDbId0"
+                    ]
+                },
+                {
+                    "description": "Call to retrieve the list of study types.",
+                    "endpoint": "/studytypes",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Studies/getStudytypesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /studytypes",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/studytypes"
+                    },
+                    "requires": []
+                }
+            ],
+            "name": "Studies"
+        },
+        {
+            "description": "Information about Observations",
+            "item": [
+                {
+                    "description": "Call to retrieve the list of supported observation levels. \nObservation levels indicate the granularity level at which the measurements are taken. \nThe values are used to supply the `observationLevel` parameter in the observation unit details call.",
+                    "endpoint": "/observationlevels",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/getObservationlevelsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /observationlevels",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/observationlevels"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get a set of observation units",
+                    "endpoint": "/observationunits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/getObservationunitsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /observationunits",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/observationunits"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Notes: \n\nAlong with the study specific phenotype saving calls (in the observationUnit and table formats), this call allows phenotypes to be saved and images to optionally be transferred as well.\n\nCall to invoke for saving the measurements (observations) collected\\nfrom field for all the observation units.\n\nObservation timestamp should be ISO 8601 https://www.w3.org/TR/NOTE-datetime \n\nIn case where JSON data is zipped for faster transfer speed (as in the case of the IRRI handheld implementation), the zipped JSON file will be listed in datafiles. The zipped file contains a JSON file with the same structure as the BrAPI call. In this case a format parameter should be passed as well. \n\nImages can be optionally be uploaded using this call by providing a zipfile of all images in the datafiles, along with the actual zipfile in multi-part form data.\"",
+                    "endpoint": "/phenotypes",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/postPhenotypesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /phenotypes",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/phenotypes"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Returns a list of observationUnit with the observed Phenotypes.\n\nobservationTimeStamp - Iso Standard 8601.\n\nobservationValue data type inferred from the ontology",
+                    "endpoint": "/search/observationtables",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/postSearchObservationtablesResponse",
+                                "GetValue:/result/searchResultDbId:observationtablesSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/observationtables",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/observationtables"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Returns a list of observationUnit with the observed Phenotypes.\n\nobservationTimeStamp - Iso Standard 8601.\n\nobservationValue data type inferred from the ontology\n",
+                    "endpoint": "/search/observationtables/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/getSearchObservationtablesSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/observationtables/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/observationtables/{observationtablesSearchResultDbId}"
+                    },
+                    "requires": [
+                        "observationtablesSearchResultDbId"
+                    ]
+                },
+                {
+                    "description": "Returns a list of observationUnit with the observed Phenotypes.\n\nSee Search Services for additional implementation details.\n\nUse case - this section allows to get a dataset from multiple studies. It allows to integrate data from several databases.\n\nRefactor note - This call allows to get and integrate portions of multiple phenotyping data matrixes. A proposed evolution allowed to get a list of single observations, this functionality is still possible with this call by specifybing the observation variable, see below.\n\nExample Use cases \n\n- Study a panel of germplasm accross multiple studies\n\n    '{\"germplasmDbIds\": [\"Syrah\", \"34Mtp362\"]}'\n\n- Get all data for a specific study (same as \"/studies/{studyDbId}/observationunits\")\n\n    '{\"studyDbIds\" : [\"383\"]}'\n\n- Get simple atomic phenotyping values \n\n    '{\n\n       \"germplasmDbIds\" : [ \"Syrah\", \"34Mtp362\" ], \n\n       \"observationVariableDbIds\" : [ \"CO_345:0000043\"]\n\n     }'\n\n- Study Locations for adaptation to climate change\n\n    '{\n\n       \"locationDbIds\" : [\"383838\", \"MONTPELLIER\"], \n\n       \"germplasmDbIds\" : [ \"14Mtp361\", \"24Mtp362\", \"34Mtp363\", \"44Mtp364\"]\n\n     }'\n\n- Find phenotypes that are from after a certain timestamp\n\n    '{\n\n       \"observationTimeStampRangeStart\" : \"2013-06-14T23:59:59-04:00\", \n\n       \"observationTimeStampRangeEnd\" : \"2013-06-15T23:59:59-04:00\"\n\n     }'\n     \nobservationTimeStampRangeStart and observationTimeStampRangeEnd use Iso Standard 8601.\n\nobservationValue data type inferred from the ontology",
+                    "endpoint": "/search/observationunits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/postSearchObservationunitsResponse",
+                                "GetValue:/result/searchResultDbId:observationunitsSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/observationunits",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/observationunits"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Returns a list of observationUnit with the observed Phenotypes.\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/observationunits/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Observations/getSearchObservationunitsSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/observationunits/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/observationunits/{observationunitsSearchResultDbId}"
+                    },
+                    "requires": [
+                        "observationunitsSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Observations"
+        },
+        {
+            "description": "API to retrieve list and details of observation variables. An observation variable is composed by the unique combination of one Trait, one Method and one Scale.",
+            "item": [
+                {
+                    "description": "Returns a list of Methods available on a server.\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/methods",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getMethodsResponse",
+                                "GetValue:/result/data/0/methodDbId:methodDbId0",
+                                "GetValue:/result/data/1/methodDbId:methodDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /methods",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/methods"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new method object in the database",
+                    "endpoint": "/methods",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/postMethodsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /methods",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/methods"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve details about a specific method\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/methods/{methodDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getMethodsMethoddbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /methods/{methodDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/methods/{methodDbId0}"
+                    },
+                    "requires": [
+                        "methodDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve details about a specific method\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/methods/{methodDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getMethodsMethoddbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /methods/{methodDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/methods/{methodDbId1}"
+                    },
+                    "requires": [
+                        "methodDbId1"
+                    ]
+                },
+                {
+                    "description": "Update the details of an existing method",
+                    "endpoint": "/methods/{methodDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/putMethodsMethoddbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /methods/{methodDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/methods/{methodDbId0}"
+                    },
+                    "requires": [
+                        "methodDbId0"
+                    ]
+                },
+                {
+                    "description": "Call to retrieve a list of observation variable ontologies available in the system.",
+                    "endpoint": "/ontologies",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getOntologiesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /ontologies",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/ontologies"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Returns a list of Scales available on a server.\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/scales",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getScalesResponse",
+                                "GetValue:/result/data/0/scaleDbId:scaleDbId0",
+                                "GetValue:/result/data/1/scaleDbId:scaleDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /scales",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/scales"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new scale object in the database",
+                    "endpoint": "/scales",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/postScalesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /scales",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/scales"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve details about a specific scale\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/scales/{scaleDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getScalesScaledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /scales/{scaleDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/scales/{scaleDbId0}"
+                    },
+                    "requires": [
+                        "scaleDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve details about a specific scale\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/scales/{scaleDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getScalesScaledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /scales/{scaleDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/scales/{scaleDbId1}"
+                    },
+                    "requires": [
+                        "scaleDbId1"
+                    ]
+                },
+                {
+                    "description": "Update the details of an existing scale",
+                    "endpoint": "/scales/{scaleDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/putScalesScaledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /scales/{scaleDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/scales/{scaleDbId0}"
+                    },
+                    "requires": [
+                        "scaleDbId0"
+                    ]
+                },
+                {
+                    "description": "Search observation variables.\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/variables",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/postSearchVariablesResponse",
+                                "GetValue:/result/searchResultDbId:variablesSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/variables",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/variables"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Search observation variables.\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/variables/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getSearchVariablesSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/variables/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/variables/{variablesSearchResultDbId}"
+                    },
+                    "requires": [
+                        "variablesSearchResultDbId"
+                    ]
+                },
+                {
+                    "description": "Call to retrieve a list of traits available in the system and their associated variables.\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/traits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getTraitsResponse",
+                                "GetValue:/result/data/0/traitDbId:traitDbId0",
+                                "GetValue:/result/data/1/traitDbId:traitDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /traits",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/traits"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new trait object in the database",
+                    "endpoint": "/traits",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/postTraitsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /traits",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/traits"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve the details of a single trait\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/traits/{traitDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getTraitsTraitdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /traits/{traitDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/traits/{traitDbId0}"
+                    },
+                    "requires": [
+                        "traitDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the details of a single trait\n\nAn Observation Variable has 3 critical parts: A Trait being observed, a Method for making the observation, and a Scale on which the observation can be measured and compared with other observations.",
+                    "endpoint": "/traits/{traitDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getTraitsTraitdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /traits/{traitDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/traits/{traitDbId1}"
+                    },
+                    "requires": [
+                        "traitDbId1"
+                    ]
+                },
+                {
+                    "description": "Update an existing trait",
+                    "endpoint": "/traits/{traitDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/putTraitsTraitdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /traits/{traitDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/traits/{traitDbId0}"
+                    },
+                    "requires": [
+                        "traitDbId0"
+                    ]
+                },
+                {
+                    "description": "Call to retrieve a list of observationVariables available in the system.",
+                    "endpoint": "/variables",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getVariablesResponse",
+                                "GetValue:/result/data/0/observationVariableDbId:observationVariableDbId0",
+                                "GetValue:/result/data/1/observationVariableDbId:observationVariableDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /variables",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/variables"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve variable details",
+                    "endpoint": "/variables/{observationVariableDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /variables/{observationVariableDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/variables/{observationVariableDbId0}"
+                    },
+                    "requires": [
+                        "observationVariableDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve variable details",
+                    "endpoint": "/variables/{observationVariableDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /variables/{observationVariableDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/variables/{observationVariableDbId1}"
+                    },
+                    "requires": [
+                        "observationVariableDbId1"
+                    ]
+                }
+            ],
+            "name": "Observation Variables"
+        },
+        {
+            "description": "Information about Phenotypes",
+            "item": [],
+            "name": "Phenotypes"
+        },
+        {
+            "description": "Information about Germplasm",
+            "item": [
+                {
+                    "description": "Get the list of germplasm breeding methods available in a system.",
+                    "endpoint": "/breedingmethods",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getBreedingmethodsResponse",
+                                "GetValue:/result/data/0/breedingMethodDbId:breedingMethodDbId0",
+                                "GetValue:/result/data/1/breedingMethodDbId:breedingMethodDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /breedingmethods",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/breedingmethods"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get the details of a specific Breeding Method used to produce Germplasm",
+                    "endpoint": "/breedingmethods/{breedingMethodDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getBreedingmethodsBreedingmethoddbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /breedingmethods/{breedingMethodDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/breedingmethods/{breedingMethodDbId0}"
+                    },
+                    "requires": [
+                        "breedingMethodDbId0"
+                    ]
+                },
+                {
+                    "description": "Get the details of a specific Breeding Method used to produce Germplasm",
+                    "endpoint": "/breedingmethods/{breedingMethodDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getBreedingmethodsBreedingmethoddbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /breedingmethods/{breedingMethodDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/breedingmethods/{breedingMethodDbId1}"
+                    },
+                    "requires": [
+                        "breedingMethodDbId1"
+                    ]
+                },
+                {
+                    "description": "Addresses these needs\n\n- General germplasm search mechanism that accepts POST for complex queries \n\n- Possibility to search germplasm by more parameters than those allowed by the existing germplasm search \n\n- Possibility to get MCPD details by PUID rather than dbId",
+                    "endpoint": "/germplasm",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmResponse",
+                                "GetValue:/result/data/0/germplasmDbId:germplasmDbId0",
+                                "GetValue:/result/data/1/germplasmDbId:germplasmDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Germplasm Details by germplasmDbId was merged with Germplasm Multi Crop Passport Data. The MCPD fields are optional and marked with the prefix [MCPD].",
+                    "endpoint": "/germplasm/{germplasmDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Germplasm Details by germplasmDbId was merged with Germplasm Multi Crop Passport Data. The MCPD fields are optional and marked with the prefix [MCPD].",
+                    "endpoint": "/germplasm/{germplasmDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId1}"
+                    },
+                    "requires": [
+                        "germplasmDbId1"
+                    ]
+                },
+                {
+                    "description": "Values for all attributes by default.",
+                    "endpoint": "/germplasm/{germplasmDbId}/attributes",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidAttributesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}/attributes",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}/attributes"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the markerProfileDbIds for a given Germplasm ID",
+                    "endpoint": "/germplasm/{germplasmDbId}/markerprofiles",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidMarkerprofilesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}/markerprofiles",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}/markerprofiles"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Get all MCPD details of a germplasm\n\n<a target=\"_blank\" href=\"https://www.bioversityinternational.org/fileadmin/user_upload/online_library/publications/pdfs/FAOBIOVERSITY_MULTI-CROP_PASSPORT_DESCRIPTORS_V.2.1_2015_2020.pdf\"> MCPD v2.1 spec can be found here </a>\n\nImplementation Notes\n\n- When the MCPD spec identifies a field which can have multiple values returned, the JSON response should be an array instead of a semi-colon seperated string.",
+                    "endpoint": "/germplasm/{germplasmDbId}/mcpd",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidMcpdResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}/mcpd",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}/mcpd"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Get the parentage information of a specific Germplasm",
+                    "endpoint": "/germplasm/{germplasmDbId}/pedigree",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidPedigreeResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}/pedigree",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}/pedigree"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Get the germplasmDbIds for all the Progeny of a particular germplasm.\n\nImplementation Notes\n\n- Regarding the 'parentType' field in the progeny object. Given a germplasm A having a progeny B and C, 'parentType' for progeny B refers to the 'parentType' of A toward B.",
+                    "endpoint": "/germplasm/{germplasmDbId}/progeny",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getGermplasmGermplasmdbidProgenyResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /germplasm/{germplasmDbId}/progeny",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/germplasm/{germplasmDbId0}/progeny"
+                    },
+                    "requires": [
+                        "germplasmDbId0"
+                    ]
+                },
+                {
+                    "description": "Search for a set of germplasm based on some criteria\n\nAddresses these needs \n\n- General germplasm search mechanism that accepts POST for complex queries \n\n- Possibility to search germplasm by more parameters than those allowed by the existing germplasm search \n\n- Possibility to get MCPD details by PUID rather than dbId\n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/germplasm",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/postSearchGermplasmResponse",
+                                "GetValue:/result/searchResultDbId:germplasmSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/germplasm",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/germplasm"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "See Search Services for additional implementation details.\nAddresses these needs: 1. General germplasm search mechanism that accepts POST for complex queries 2. possibility to search germplasm by more parameters than those allowed by the existing germplasm search 3. possibility to get MCPD details by PUID rather than dbId",
+                    "endpoint": "/search/germplasm/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Germplasm/getSearchGermplasmSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/germplasm/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/germplasm/{germplasmSearchResultDbId}"
+                    },
+                    "requires": [
+                        "germplasmSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Germplasm"
+        },
+        {
+            "description": "Information about Germplasm Attributes",
+            "item": [
+                {
+                    "description": "List available attributes.",
+                    "endpoint": "/attributes",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GermplasmAttributes/getAttributesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /attributes",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/attributes"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "List all available attribute categories.",
+                    "endpoint": "/attributes/categories",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GermplasmAttributes/getAttributesCategoriesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /attributes/categories",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/attributes/categories"
+                    },
+                    "requires": []
+                }
+            ],
+            "name": "Germplasm Attributes"
+        },
+        {
+            "description": "Information about Markers",
+            "item": [
+                {
+                    "description": "Other service requests use the servers internal `markerDbId`. This service returns marker records that provide the markerDbId. For the requested name or synonym, returns an array (possibly empty) of marker records that match the search criteria.\nIf there is none, an empty array is returned. If there is one or more than one match, returns an array of all marker records that match the search criteria.",
+                    "endpoint": "/markers",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Markers/getMarkersResponse",
+                                "GetValue:/result/data/0/markerDbId:markerDbId0",
+                                "GetValue:/result/data/1/markerDbId:markerDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markers",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markers"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Status: ACCEPTED \nImplemented By:",
+                    "endpoint": "/markers/{markerDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Markers/getMarkersMarkerdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markers/{markerDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markers/{markerDbId0}"
+                    },
+                    "requires": [
+                        "markerDbId0"
+                    ]
+                },
+                {
+                    "description": "Status: ACCEPTED \nImplemented By:",
+                    "endpoint": "/markers/{markerDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Markers/getMarkersMarkerdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markers/{markerDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markers/{markerDbId1}"
+                    },
+                    "requires": [
+                        "markerDbId1"
+                    ]
+                },
+                {
+                    "description": "See Search Services for additional implementation details.\nOther service requests use the servers internal `markerDbId`. This service returns marker records that provide the markerDbId. For the requested name or synonym, returns an array (possibly empty) of marker records that match the search criteria. \nIf there is none, an empty array is returned. If there is one or more than one match, returns an array of all marker records that match the search criteria. '",
+                    "endpoint": "/search/markers",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Markers/postSearchMarkersResponse",
+                                "GetValue:/result/searchResultDbId:markersSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/markers",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/markers"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "See Search Services for additional implementation details. Other service requests use the servers internal `markerDbId`. This service returns marker records that provide the markerDbId. For the requested name or synonym, returns an array (possibly empty) of marker records that match the search criteria. - If there is none, an empty array is returned. - If there is one or more than one match, returns an array of all marker records that match the search criteria. '",
+                    "endpoint": "/search/markers/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Markers/getSearchMarkersSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/markers/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/markers/{markersSearchResultDbId}"
+                    },
+                    "requires": [
+                        "markersSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Markers"
+        },
+        {
+            "description": "Information about Marker Profiles",
+            "item": [
+                {
+                    "description": "This resource is used for reading and writing genomic matrices\n\nGET provides a list of available matrices, optionally filtered by study;",
+                    "endpoint": "/allelematrices",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/getAllelematricesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /allelematrices",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/allelematrices"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "See Search Services for additional implementation details.\n\nThis uses a more efficient data structure and pagination for large number of markers.\n\nSee Search Services for additional implementation details.\n\nUse GET when parameter size is less than 2K bytes.\n\nThis method may support asynchronous processing.",
+                    "endpoint": "/allelematrices-search",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/getAllelematrices-searchResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /allelematrices-search",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/allelematrices-search"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "See Search Services for additional implementation details.\n\nThis uses a more efficient data structure and pagination for large number of markers.\n\nUse POST when parameter size is greater than 2K bytes.\n\n- If no format is specified, this call returns the data in JSON form.\n\n- If a format (other than JSON) is specified and the server supports this format, it will return the link to the exported data file in the \"datafiles\" field of the \"metadata\".\n\n- If more than one format is requested at a time, the server will throw a \"501 Not Implemented\" error.\n\nThe format of the tsv response can be found on GitHub (https://github.com/plantbreeding/Documentation/wiki/BrAPI-TSV-Expected-Formats)'",
+                    "endpoint": "/allelematrices-search",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/postAllelematrices-searchResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /allelematrices-search",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/allelematrices-search"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "For the requested Germplasm Id and/or Extract Id, returns the Markerprofile Id and number of non-missing allele calls (marker/allele pairs).",
+                    "endpoint": "/markerprofiles",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/getMarkerprofilesResponse",
+                                "GetValue:/result/data/0/markerProfileDbId:markerProfileDbId0",
+                                "GetValue:/result/data/1/markerProfileDbId:markerProfileDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markerprofiles",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markerprofiles"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "For the requested marker profile ID, returns the allele call for each marker. \n        \nAllele encodings\n\n- Unknown data will by default be encoded by \\\"N\\\"\n\n- Homozygotes are returned as a single occurance, e.g. AA -> A, GG -> G\n\n- Phased heterozygotes are by default separated by a pipe (\\\"|\\\") and unphased heterozygotes are by default separated by a forward slash (\\\"/\\\")\n\n- Dominant markers such as DArTs: 1 for present, 0 for absent\n        \n- If the user would like to use an empty string (\\\"\\\") for any of the parameters, the value should be set to the reserved word \\\"empty_string\\\", e.g. sepUnphased=empty_string.\n\nOpen issue: The pages of data will need to be sorted sensibly in order for the requested page to be delivered consistently.  By map or genome position? Alphabetically?'\"",
+                    "endpoint": "/markerprofiles/{markerProfileDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/getMarkerprofilesMarkerprofiledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markerprofiles/{markerProfileDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markerprofiles/{markerProfileDbId0}"
+                    },
+                    "requires": [
+                        "markerProfileDbId0"
+                    ]
+                },
+                {
+                    "description": "For the requested marker profile ID, returns the allele call for each marker. \n        \nAllele encodings\n\n- Unknown data will by default be encoded by \\\"N\\\"\n\n- Homozygotes are returned as a single occurance, e.g. AA -> A, GG -> G\n\n- Phased heterozygotes are by default separated by a pipe (\\\"|\\\") and unphased heterozygotes are by default separated by a forward slash (\\\"/\\\")\n\n- Dominant markers such as DArTs: 1 for present, 0 for absent\n        \n- If the user would like to use an empty string (\\\"\\\") for any of the parameters, the value should be set to the reserved word \\\"empty_string\\\", e.g. sepUnphased=empty_string.\n\nOpen issue: The pages of data will need to be sorted sensibly in order for the requested page to be delivered consistently.  By map or genome position? Alphabetically?'\"",
+                    "endpoint": "/markerprofiles/{markerProfileDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/MarkerProfiles/getMarkerprofilesMarkerprofiledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /markerprofiles/{markerProfileDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/markerprofiles/{markerProfileDbId1}"
+                    },
+                    "requires": [
+                        "markerProfileDbId1"
+                    ]
+                }
+            ],
+            "name": "Marker Profiles"
+        },
+        {
+            "description": "Information about Genome Maps",
+            "item": [
+                {
+                    "description": "Get list of maps",
+                    "endpoint": "/maps",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GenomeMaps/getMapsResponse",
+                                "GetValue:/result/data/0/mapDbId:mapDbId0",
+                                "GetValue:/result/data/1/mapDbId:mapDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /maps",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/maps"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Provides the number of markers on each linkageGroup and the max position on the linkageGroup",
+                    "endpoint": "/maps/{mapDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GenomeMaps/getMapsMapdbidResponse",
+                                "GetValue:/result/data/0/linkageGroupName:linkageGroupName0"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /maps/{mapDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/maps/{mapDbId0}"
+                    },
+                    "requires": [
+                        "mapDbId0"
+                    ]
+                },
+                {
+                    "description": "Provides the number of markers on each linkageGroup and the max position on the linkageGroup",
+                    "endpoint": "/maps/{mapDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GenomeMaps/getMapsMapdbidResponse",
+                                "GetValue:/result/data/0/linkageGroupName:linkageGroupName0"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /maps/{mapDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/maps/{mapDbId1}"
+                    },
+                    "requires": [
+                        "mapDbId1"
+                    ]
+                },
+                {
+                    "description": "All the markers in a given Map, ordered by linkageGroup and position.",
+                    "endpoint": "/maps/{mapDbId}/positions",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GenomeMaps/getMapsMapdbidPositionsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /maps/{mapDbId}/positions",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/maps/{mapDbId0}/positions"
+                    },
+                    "requires": [
+                        "mapDbId0"
+                    ]
+                },
+                {
+                    "description": "All the markers in a specific Linkage Group (aka Chromasome) inside a particular Map, ordered by position.",
+                    "endpoint": "/maps/{mapDbId}/positions/{linkageGroupName}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/GenomeMaps/getMapsMapdbidPositionsLinkagegroupnameResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /maps/{mapDbId}/positions/{linkageGroupName}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/maps/{mapDbId0}/positions/{linkageGroupName0}"
+                    },
+                    "requires": [
+                        "mapDbId0",
+                        "linkageGroupName0"
+                    ]
+                }
+            ],
+            "name": "Genome Maps"
+        },
+        {
+            "description": "Information about Samples",
+            "item": [
+                {
+                    "description": "Used to retrieve list of Samples from a Sample Tracking system based on some search criteria.",
+                    "endpoint": "/samples",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/getSamplesResponse",
+                                "GetValue:/result/data/0/sampleDbId:sampleDbId0",
+                                "GetValue:/result/data/1/sampleDbId:sampleDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /samples",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/samples"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Call to register the event of a sample being taken. Sample ID is assigned as a result of the operation and returned in response.",
+                    "endpoint": "/samples",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/putSamplesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /samples",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/samples"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Used to retrieve the details of a single Sample from a Sample Tracking system.",
+                    "endpoint": "/samples/{sampleDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/getSamplesSampledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /samples/{sampleDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/samples/{sampleDbId0}"
+                    },
+                    "requires": [
+                        "sampleDbId0"
+                    ]
+                },
+                {
+                    "description": "Used to retrieve the details of a single Sample from a Sample Tracking system.",
+                    "endpoint": "/samples/{sampleDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/getSamplesSampledbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /samples/{sampleDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/samples/{sampleDbId1}"
+                    },
+                    "requires": [
+                        "sampleDbId1"
+                    ]
+                },
+                {
+                    "description": "Used to retrieve list of Samples from a Sample Tracking system based on some search criteria.\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/samples",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/postSearchSamplesResponse",
+                                "GetValue:/result/searchResultDbId:samplesSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/samples",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/samples"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Used to retrieve list of Samples from a Sample Tracking system based on some search criteria.\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/samples/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Samples/getSearchSamplesSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/samples/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/samples/{samplesSearchResultDbId}"
+                    },
+                    "requires": [
+                        "samplesSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Samples"
+        },
+        {
+            "description": "This interface is specific to facilities that performs an external analysis, such as genotyping facilities. The interface should be implemented by that facility's server. The breeding database is the client of this interface.\nNote that to use these calls, you likely have to use the authentication call prior to connecting (see Authentication best practices).",
+            "item": [
+                {
+                    "description": "List current available orders",
+                    "endpoint": "/vendor/orders",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorOrdersResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/orders",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/orders"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Submit a new order to a vendor",
+                    "endpoint": "/vendor/orders",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/postVendorOrdersResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /vendor/orders",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/vendor/orders"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Retrieve the plate and sample details of an order being processed",
+                    "endpoint": "/vendor/orders/{orderId}/plates",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorOrdersOrderidPlatesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/orders/{orderId}/plates",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/orders/{orderId0}/plates"
+                    },
+                    "requires": [
+                        "orderId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the data files generated by the vendors analysis",
+                    "endpoint": "/vendor/orders/{orderId}/results",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorOrdersOrderidResultsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/orders/{orderId}/results",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/orders/{orderId0}/results"
+                    },
+                    "requires": [
+                        "orderId0"
+                    ]
+                },
+                {
+                    "description": "Retrieve the current status of an order being processed",
+                    "endpoint": "/vendor/orders/{orderId}/status",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorOrdersOrderidStatusResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/orders/{orderId}/status",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/orders/{orderId0}/status"
+                    },
+                    "requires": [
+                        "orderId0"
+                    ]
+                },
+                {
+                    "description": "Submit a new set of Sample data",
+                    "endpoint": "/vendor/plates",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/postVendorPlatesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /vendor/plates",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/vendor/plates"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get data for a submitted set of plates",
+                    "endpoint": "/vendor/plates/{submissionId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorPlatesSubmissionidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/plates/{submissionId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/plates/{submissionId0}"
+                    },
+                    "requires": [
+                        "submissionId0"
+                    ]
+                },
+                {
+                    "description": "Defines the plate format specification for the vendor.",
+                    "endpoint": "/vendor/specifications",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Vendor/getVendorSpecificationsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /vendor/specifications",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/vendor/specifications"
+                    },
+                    "requires": []
+                }
+            ],
+            "name": "Vendor"
+        },
+        {
+            "description": "Create and manipulate generic lists",
+            "item": [
+                {
+                    "description": "Get filtered set of generic lists",
+                    "endpoint": "/lists",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/getListsResponse",
+                                "GetValue:/result/data/0/listDbId:listDbId0",
+                                "GetValue:/result/data/1/listDbId:listDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /lists",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/lists"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new list",
+                    "endpoint": "/lists",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/postListsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /lists",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/lists"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get a specific generic lists",
+                    "endpoint": "/lists/{listDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/getListsListdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /lists/{listDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/lists/{listDbId0}"
+                    },
+                    "requires": [
+                        "listDbId0"
+                    ]
+                },
+                {
+                    "description": "Get a specific generic lists",
+                    "endpoint": "/lists/{listDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/getListsListdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /lists/{listDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/lists/{listDbId1}"
+                    },
+                    "requires": [
+                        "listDbId1"
+                    ]
+                },
+                {
+                    "description": "Update an existing generic list",
+                    "endpoint": "/lists/{listDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/putListsListdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /lists/{listDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/lists/{listDbId0}"
+                    },
+                    "requires": [
+                        "listDbId0"
+                    ]
+                },
+                {
+                    "description": "Add new data to a specific generic lists",
+                    "endpoint": "/lists/{listDbId}/items",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Lists/postListsListdbidItemsResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /lists/{listDbId}/items",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/lists/{listDbId0}/items"
+                    },
+                    "requires": [
+                        "listDbId0"
+                    ]
+                }
+            ],
+            "name": "Lists"
+        },
+        {
+            "description": "Create and manipulate image data",
+            "item": [
+                {
+                    "description": "Get filtered set of image meta data\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's.  ",
+                    "endpoint": "/images",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/getImagesResponse",
+                                "GetValue:/result/data/0/imageDbId:imageDbId0",
+                                "GetValue:/result/data/1/imageDbId:imageDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /images",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/images"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new image meta data object\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's.\n\n- The `/images` calls support a GeoJSON object structure for describing their location. The BrAPI spec for GeoJSON only supports two of the possible geometries: Points and Polygons.\n\n- With most images, the Point geometry should be used, and it should indicate the longitude and latitude of the camera.\n\n- For top down images (ie from drones, cranes, etc), the Point geometry may be used to indicate the longitude and latitude of the centroid of the image content, and the Polygon geometry may be used to indicate the border of the image content. ",
+                    "endpoint": "/images",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/postImagesResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /images",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/images"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get one image meta data object\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's. ",
+                    "endpoint": "/images/{imageDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/getImagesImagedbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /images/{imageDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/images/{imageDbId0}"
+                    },
+                    "requires": [
+                        "imageDbId0"
+                    ]
+                },
+                {
+                    "description": "Get one image meta data object\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's. ",
+                    "endpoint": "/images/{imageDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/getImagesImagedbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /images/{imageDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/images/{imageDbId1}"
+                    },
+                    "requires": [
+                        "imageDbId1"
+                    ]
+                },
+                {
+                    "description": "Update an image meta data object\n\nImplementation Notes\n\n- This call should be paired with 'PUT /images/{imageDbId}/imagecontent' for full capability\n\n- A server may choose to modify the image meta data object based on the actually image which has been uploaded. \n\n- Image data may be stored in a database or file system. Servers should generate and provide the \\\"imageURL\\\" as an absolute path for retrieving the image, wherever it happens to live. \n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's. \n\n- The `/images` calls support a GeoJSON object structure for describing their location. The BrAPI spec for GeoJSON only supports two of the possible geometries: Points and Polygons. \n        \n- With most images, the Point geometry should be used, and it should indicate the longitude and latitude of the camera. \n        \n- For top down images (ie from drones, cranes, etc), the Point geometry may be used to indicate the longitude and latitude of the centroid of the image content, and the Polygon geometry may be used to indicate the border of the image content. '",
+                    "endpoint": "/images/{imageDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/putImagesImagedbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /images/{imageDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/images/{imageDbId0}"
+                    },
+                    "requires": [
+                        "imageDbId0"
+                    ]
+                },
+                {
+                    "description": "Update an image with the image file content\n\nImplementation Notes\n\n- This call should be paired with 'PUT /images/{imageDbId}' for full capability\n\n- A server may choose to modify the image meta data object based on the actually image which has been uploaded. \n\n- Image data may be stored in a database or file system. Servers should generate and provide the \"imageURL\" for retrieving the image, wherever it happens to live.  ",
+                    "endpoint": "/images/{imageDbId}/imagecontent",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/putImagesImagedbidImagecontentResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /images/{imageDbId}/imagecontent",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/images/{imageDbId0}/imagecontent"
+                    },
+                    "requires": [
+                        "imageDbId0"
+                    ]
+                },
+                {
+                    "description": "Get filtered set of image meta data\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's.  \n\nSee Search Services for additional implementation details.",
+                    "endpoint": "/search/images",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/postSearchImagesResponse",
+                                "GetValue:/result/searchResultDbId:imagesSearchResultDbId"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /search/images",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/search/images"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get filtered set of image meta data\n\nImplementation Notes\n\n- 'imageURL' should be a complete URL decribing the location of the image. There is no BrAPI call for retireiving the image content, so it could be on a different path, or a different host.\n\n- 'descriptiveOntologyTerm' can be thought of as Tags for the image. These could be simple descriptive words, or ontology references, or full ontology URI's.  ",
+                    "endpoint": "/search/images/{searchResultsDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/Images/getSearchImagesSearchresultsdbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /search/images/{searchResultsDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/search/images/{imagesSearchResultDbId}"
+                    },
+                    "requires": [
+                        "imagesSearchResultDbId"
+                    ]
+                }
+            ],
+            "name": "Images"
+        },
+        {
+            "description": "Create and manipulate information about people",
+            "item": [
+                {
+                    "description": "Get filtered list of people",
+                    "endpoint": "/people",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/People/getPeopleResponse",
+                                "GetValue:/result/data/0/personDbId:personDbId0",
+                                "GetValue:/result/data/1/personDbId:personDbId1"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /people",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/people"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Create a new person",
+                    "endpoint": "/people",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/People/postPeopleResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "POST /people",
+                    "parameters": [],
+                    "request": {
+                        "method": "POST",
+                        "url": "{baseurl}/people"
+                    },
+                    "requires": []
+                },
+                {
+                    "description": "Get a specific person",
+                    "endpoint": "/people/{personDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/People/getPeoplePersondbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /people/{personDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/people/{personDbId0}"
+                    },
+                    "requires": [
+                        "personDbId0"
+                    ]
+                },
+                {
+                    "description": "Get a specific person",
+                    "endpoint": "/people/{personDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/People/getPeoplePersondbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "GET /people/{personDbId} with second DbId",
+                    "parameters": [],
+                    "request": {
+                        "method": "GET",
+                        "url": "{baseurl}/people/{personDbId1}"
+                    },
+                    "requires": [
+                        "personDbId1"
+                    ]
+                },
+                {
+                    "description": "Update an existing Person",
+                    "endpoint": "/people/{personDbId}",
+                    "event": [
+                        {
+                            "exec": [
+                                "StatusCode:200:breakiffalse",
+                                "ContentType:application/json",
+                                "Schema:/v1.3/metadata",
+                                "Schema:/v1.3/People/putPeoplePersondbidResponse"
+                            ],
+                            "listen": "test",
+                            "type": "text/plain"
+                        }
+                    ],
+                    "name": "PUT /people/{personDbId}",
+                    "parameters": [],
+                    "request": {
+                        "method": "PUT",
+                        "url": "{baseurl}/people/{personDbId0}"
+                    },
+                    "requires": [
+                        "personDbId0"
+                    ]
+                }
+            ],
+            "name": "People"
+        },
+        {
+            "description": "Authenticacte your requests",
+            "item": [],
+            "name": "Authentication"
+        },
+        {
+            "description": "Deprecated Calls",
+            "item": [],
+            "name": "Deprecated"
+        }
+    ]
+}

--- a/src/main/resources/schemas/v1.3/Calls/getCallsResponse.json
+++ b/src/main/resources/schemas/v1.3/Calls/getCallsResponse.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Array of availible calls on this server",
+                    "items": {
+                        "properties": {
+                            "call": {
+                                "description": "The name of the available call as recorded in the documentation",
+                                "type": "string"
+                            },
+                            "dataTypes": {
+                                "description": "The possible data formats returned by the available call",
+                                "items": {
+                                    "enum": [
+                                        "application/json",
+                                        "text/csv",
+                                        "text/tsv",
+                                        "application/flapjack"
+                                    ],
+                                    "title": "WSMIMEDataTypes",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "methods": {
+                                "description": "The possible HTTP Methods to be used with the available call",
+                                "items": {
+                                    "enum": [
+                                        "GET",
+                                        "POST",
+                                        "PUT",
+                                        "DELETE"
+                                    ],
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "versions": {
+                                "description": "The supported versions of a particular call",
+                                "items": {
+                                    "enum": [
+                                        "1.0",
+                                        "1.1",
+                                        "1.2",
+                                        "1.3"
+                                    ],
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "call",
+                            "dataTypes",
+                            "methods"
+                        ],
+                        "title": "call",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getCallsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Crops/getCommoncropnamesResponse.json
+++ b/src/main/resources/schemas/v1.3/Crops/getCommoncropnamesResponse.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "array of crop names availible on the server",
+                    "items": {
+                        "description": "supported crop name",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getCommoncropnamesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidPositionsLinkagegroupnameResponse.json
+++ b/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidPositionsLinkagegroupnameResponse.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "location": {
+                                "description": "The position of a marker within a linkage group",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerDbId": {
+                                "description": "Internal db identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerName": {
+                                "description": "The human readable name for a marker",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "markerSummaryLinkageGroup",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMapsMapdbidPositionsLinkagegroupnameResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidPositionsResponse.json
+++ b/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidPositionsResponse.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "linkageGroupName": {
+                                "description": "The Uniquely Identifiable name of this linkage group",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "location": {
+                                "description": "The position of a marker within a linkage group",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerDbId": {
+                                "description": "Internal db identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerName": {
+                                "description": "The human readable name for a marker",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "markerSummaryMap",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMapsMapdbidPositionsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/GenomeMaps/getMapsMapdbidResponse.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "List of linkage group details associated with a given map",
+                    "items": {
+                        "properties": {
+                            "linkageGroupName": {
+                                "description": "The Uniquely Identifiable name of this linkage group",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerCount": {
+                                "description": "The number of markers associated with this linkage group",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "maxPosition": {
+                                "description": "The maximum position of a marker within this linkage group",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            }
+                        },
+                        "title": "linkageGroup",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "linkageGroups": {
+                    "description": "**Deprecated** Use \"data\"",
+                    "items": {
+                        "properties": {
+                            "linkageGroupName": {
+                                "description": "The Uniquely Identifiable name of this linkage group",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerCount": {
+                                "description": "The number of markers associated with this linkage group",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "maxPosition": {
+                                "description": "The maximum position of a marker within this linkage group",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            }
+                        },
+                        "title": "linkageGroup",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "mapDbId": {
+                    "description": "The ID which uniquely identifies this genome map",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mapName": {
+                    "description": "A human readable name for this map",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "type": {
+                    "description": "The type of map this represents, ussually \"Genetic\" or \"Physical\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "unit": {
+                    "description": "The units used to describe the data in this map",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "genomeMapDetails",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMapsMapdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GenomeMaps/getMapsResponse.json
+++ b/src/main/resources/schemas/v1.3/GenomeMaps/getMapsResponse.json
@@ -1,0 +1,102 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "comments": {
+                                "description": "Additional comments",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "The common name of the crop, found from \"GET /commoncropnames\"",
+                                "type": "string"
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "linkageGroupCount": {
+                                "description": "The number of linkage groups present in this genome map",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "mapDbId": {
+                                "description": "The ID which uniquely identifies this genome map",
+                                "type": "string"
+                            },
+                            "mapName": {
+                                "description": "A human readable name for this genome map",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerCount": {
+                                "description": "The number of markers present in this genome map",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "publishedDate": {
+                                "description": "The date this genome was published",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "scientificName": {
+                                "description": "Full scientific binomial format name. This includes Genus, Species, and Sub-species",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of map this represents, ussually \"Genetic\"",
+                                "type": "string"
+                            },
+                            "unit": {
+                                "description": "The units used to describe the data in this map",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "mapDbId",
+                            "commonCropName",
+                            "type"
+                        ],
+                        "title": "genomeMap",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMapsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getBreedingmethodsBreedingmethoddbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getBreedingmethodsBreedingmethoddbidResponse.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "abbreviation": {
+                    "description": "an abbreviation for the name of this breeding method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "breedingMethodDbId": {
+                    "description": "the unique identifier for this breeding method",
+                    "type": "string"
+                },
+                "breedingMethodName": {
+                    "description": "human readable name of the breeding method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "human readable description of the breeding method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "breedingMethodDbId"
+            ],
+            "title": "breedingMethod",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getBreedingmethodsBreedingmethoddbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getBreedingmethodsResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getBreedingmethodsResponse.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "abbreviation": {
+                                "description": "an abbreviation for the name of this breeding method",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "breedingMethodDbId": {
+                                "description": "the unique identifier for this breeding method",
+                                "type": "string"
+                            },
+                            "breedingMethodName": {
+                                "description": "human readable name of the breeding method",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "human readable description of the breeding method",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "breedingMethodDbId"
+                        ],
+                        "title": "breedingMethod",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getBreedingmethodsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidAttributesResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidAttributesResponse.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "List of attributes associated with the given germplasm",
+                    "items": {
+                        "properties": {
+                            "attributeCode": {
+                                "description": "Short abbreviation which represents this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeDbId": {
+                                "description": "The ID which uniquely identifies this attribute within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeName": {
+                                "description": "The human readable name of this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "determinedDate": {
+                                "description": "The date the value of this attribute was determined for a given germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "value": {
+                                "description": "The value of this attribute for a given germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "germplasmAttribute",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "The ID which uniquely identifies a germplasm within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "germplasmAttributeList",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidAttributesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidMarkerprofilesResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidMarkerprofilesResponse.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "germplasmDbId": {
+                    "description": "The ID which uniquely identifies a germplasm within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "markerProfileDbIds": {
+                    "description": "The ID which uniquely identifies a marker profile within the given database server",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "germplasmMarkerprofilesList",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidMarkerprofilesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidMcpdResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidMcpdResponse.json
@@ -1,0 +1,452 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "accessionNames": {
+                    "description": "MCPD (v2.1) (ACCENAME) 11. Either a registered or other designation given to the material received, other than the donors accession number (23) or collecting number (3). First letter uppercase. Multiple names are separated by a semicolon without space. Example: Accession name: Bogatyr;Symphony;Emma.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "accessionNumber": {
+                    "description": "MCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "acquisitionDate": {
+                    "description": "MCPD (v2.1) (ACQDATE) 12. Date on which the accession entered the collection [YYYYMMDD] where YYYY is the year, MM is the month and DD is the day. Missing data (MM or DD) should be indicated with hyphens or \"00\" [double zero].",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "acquisitionSourceCode": {
+                    "description": "MCPD (v2.1) (COLLSRC) 21. The coding scheme proposed can be used at 2 different levels of detail: either by using the general codes (in boldface) such as 10, 20, 30, 40, etc., or by using the more specific codes, such as 11, 12, etc. 10) Wild habitat 11) Forest or woodland 12) Shrubland 13) Grassland 14) Desert or tundra 15) Aquatic habitat 20) Farm or cultivated habitat 21) Field 22) Orchard 23) Backyard, kitchen or home garden (urban, peri-urban or rural) 24) Fallow land 25) Pasture 26) Farm store 27) Threshing floor 28) Park 30) Market or shop 40) Institute, Experimental station, Research organization, Genebank 50) Seed company 60) Weedy, disturbed or ruderal habitat 61) Roadside 62) Field margin 99) Other (Elaborate in REMARKS field) ",
+                    "enum": [
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "14",
+                        "15",
+                        "20",
+                        "21",
+                        "22",
+                        "23",
+                        "24",
+                        "25",
+                        "26",
+                        "27",
+                        "28",
+                        "30",
+                        "40",
+                        "50",
+                        "60",
+                        "61",
+                        "62",
+                        "99"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "alternateIDs": {
+                    "description": "MCPD (v2.1) (OTHERNUMB) 24. Any other identifiers known to exist in other collections for this accession. Use the following format: INSTCODE:ACCENUMB;INSTCODE:identifier;INSTCODE and identifier are separated by a colon without space. Pairs of INSTCODE and identifier are separated by a semicolon without space. When the institute is not known, the identifier should be preceded by a colon. ",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "ancestralData": {
+                    "description": "MCPD (v2.1) (ANCEST) 20. Information about either pedigree or other description of ancestral information (e.g. parent variety in case of mutant or selection). For example a pedigree 'Hanna/7*Atlas//Turk/8*Atlas' or a description 'mutation found in Hanna', 'selection from Irene' or 'cross involving amongst others Hanna and Irene'.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "biologicalStatusOfAccessionCode": {
+                    "description": "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes (in boldface) such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. 100) Wild 110) Natural 120) Semi-natural/wild 130) Semi-natural/sown 200) Weedy 300) Traditional cultivar/landrace 400) Breeding/research material 410) Breeders line 411) Synthetic population 412) Hybrid 413) Founder stock/base population 414) Inbred line (parent of hybrid cultivar) 415) Segregating population 416) Clonal selection 420) Genetic stock 421) Mutant (e.g. induced/insertion mutants, tilling populations) 422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) 423) Other genetic stocks (e.g. mapping populations) 500) Advanced or improved cultivar (conventional breeding methods) 600) GMO (by genetic engineering) 999) Other (Elaborate in REMARKS field)",
+                    "enum": [
+                        "100",
+                        "110",
+                        "120",
+                        "130",
+                        "200",
+                        "300",
+                        "400",
+                        "410",
+                        "411",
+                        "412",
+                        "413",
+                        "414",
+                        "415",
+                        "416",
+                        "420",
+                        "421",
+                        "422",
+                        "423",
+                        "500",
+                        "600",
+                        "999"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "breedingInstitutes": {
+                    "items": {
+                        "properties": {
+                            "instituteCode": {
+                                "description": "MCPD (v2.1) (BREDCODE) 18. FAO WIEWS code of the institute that has bred the material. If the holding institute has bred the material, the breeding institute code (BREDCODE) should be the same as the holding institute code (INSTCODE). Follows INSTCODE standard. Multiple values are separated by a semicolon without space.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "MCPD (v2.1) (BREDNAME) 18.1  Name of the institute (or person) that bred the material. This descriptor should be used only if BREDCODE cannot be filled because the FAO WIEWS code for this institute is not available. Multiple names are separated by a semicolon without space.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "collectingInfo": {
+                    "description": "Information about the collection of this germplasm",
+                    "properties": {
+                        "collectingDate": {
+                            "description": "MCPD (v2.1) (COLLDATE) 17. Collecting date of the sample [YYYYMMDD] where YYYY is the year, MM is the month and DD is the day. Missing data (MM or DD) should be indicated with hyphens or \"00\" [double zero].",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "collectingInstitutes": {
+                            "description": "Institutes which collected the sample",
+                            "items": {
+                                "properties": {
+                                    "instituteAddress": {
+                                        "description": "MCPD (v2.1) (COLLINSTADDRESS) 4.1.1  Address of the institute collecting the sample. This descriptor should be used only if COLLCODE cannot be filled since the FAO WIEWS code for this institute is not available. Multiple values are separated by a semicolon without space.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "instituteCode": {
+                                        "description": "MCPD (v2.1) (COLLCODE) 4.  FAO WIEWS code of the institute collecting the sample. If the holding institute has collected the material, the collecting institute code (COLLCODE) should be the same as the holding institute code (INSTCODE). Follows INSTCODE standard. Multiple values are separated by a semicolon without space.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "instituteName": {
+                                        "description": "MCPD (v2.1) (COLLNAME) 4.1  Name of the institute collecting the sample. This descriptor should be used only if COLLCODE cannot be filled because the FAO WIEWS code for this institute is not available. Multiple values are separated by a semicolon without space.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "collectingMissionIdentifier": {
+                            "description": "MCPD (v2.1) (COLLMISSID) 4.2 Identifier of the collecting mission used by the Collecting Institute (4 or 4.1) (e.g. \"CIATFOR052\", \"CN426\").",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "collectingNumber": {
+                            "description": "MCPD (v2.1) (COLLNUMB) 3. Original identifier assigned by the collector(s) of the sample, normally composed of the name or initials of the collector(s) followed by a number (e.g. \"FM9909\"). This identifier is essential for identifying duplicates held in different collections.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "collectingSite": {
+                            "description": "Information about the location where the sample was collected",
+                            "properties": {
+                                "coordinateUncertainty": {
+                                    "description": "MCPD (v2.1) (COORDUNCERT) 15.5 Uncertainty associated with the coordinates in metres. Leave the value empty if the uncertainty is unknown.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "elevation": {
+                                    "description": "MCPD (v2.1) (ELEVATION) 16. Elevation of collecting site expressed in metres above sea level. Negative values are allowed.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "georeferencingMethod": {
+                                    "description": "MCPD (v2.1) (GEOREFMETH) 15.7  The georeferencing method used (GPS, determined from map, gazetteer, or estimated using software). Leave the value empty if georeferencing method is not known.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "latitudeDecimal": {
+                                    "description": "MCPD (v2.1) (DECLATITUDE) 15.1 Latitude expressed in decimal degrees. Positive values are North of the Equator; negative values are South of the Equator (e.g. -44.6975).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "latitudeDegrees": {
+                                    "description": "MCPD (v2.1) (LATITUDE) 15.2 Degrees (2 digits) minutes (2 digits), and seconds (2 digits) followed by N (North) or S (South) (e.g. 103020S). Every missing digit (minutes or seconds) should be indicated with a hyphen. Leading zeros are required (e.g. 10",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "locationDescription": {
+                                    "description": "MCPD (v2.1) (COLLSITE) 14. Location information below the country level that describes where the accession was collected, preferable in English. This might include the distance in kilometres and direction from the nearest town, village or map grid reference point, (e.g. 7 km south of Curitiba in the state of Parana).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "longitudeDecimal": {
+                                    "description": "MCPD (v2.1) (DECLONGITUDE) 15.3 Longitude expressed in decimal degrees. Positive values are East of the Greenwich Meridian; negative values are West of the Greenwich Meridian (e.g. +120.9123).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "longitudeDegrees": {
+                                    "description": "MCPD (v2.1) (LONGITUDE) 15.4 Degrees (3 digits), minutes (2 digits), and seconds (2 digits) followed by E (East) or W (West) (e.g. 0762510W). Every missing digit (minutes or seconds) should be indicated with a hyphen. Leading zeros are required (e.g. 076",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "spatialReferenceSystem": {
+                                    "description": "MCPD (v2.1) (COORDDATUM) 15.6 The geodetic datum or spatial reference system upon which the coordinates given in decimal latitude and decimal longitude are based (e.g. WGS84, ETRS89, NAD83). The GPS uses the WGS84 datum.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                }
+                            },
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "commonCropName": {
+                    "description": "MCPD (v2.1) (CROPNAME) 10. Common name of the crop. Example: \"malting barley\", \"macadamia\", \"mas\". ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "countryOfOrigin": {
+                    "description": "MCPD (v2.1) (ORIGCTY) 13. 3-letter ISO 3166-1 code of the country in which the sample was originally collected (e.g. landrace, crop wild relative, farmers\" variety), bred or selected (breeding lines, GMOs, segregating populations, hybrids, modern cultivars, etc.). Note: Descriptors 14 to 16 below should be completed accordingly only if it was \"collected\".",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "donorInfo": {
+                    "description": "Information about the donor",
+                    "properties": {
+                        "donorAccessionNumber": {
+                            "description": "MCPD (v2.1) (DONORNUMB) 23. Identifier assigned to an accession by the donor. Follows ACCENUMB standard.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "donorInstitute": {
+                            "properties": {
+                                "instituteCode": {
+                                    "description": "MCPD (v2.1) (DONORCODE) 22. FAO WIEWS code of the donor institute. Follows INSTCODE standard.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "instituteName": {
+                                    "description": "MCPD (v2.1) (DONORNAME) 22.1  Name of the donor institute (or person). This descriptor should be used only if DONORCODE cannot be filled because the FAO WIEWS code for this institute is not available.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                }
+                            },
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "genus": {
+                    "description": "MCPD (v2.1) (GENUS) 5. Genus name for taxon. Initial uppercase letter required.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "A unique identifier which identifies a germplasm in this database",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmPUI": {
+                    "description": "MCPD (v2.1) (PUID) 0. Any persistent, unique identifier assigned to the accession so it can be unambiguously referenced at the global level and the information associated with it harvested through automated means. Report one PUID for each accession. The Secretariat of the International Treaty on Plant Genetic Resources for Food and Agriculture (PGRFA) is facilitating the assignment of a persistent unique identifier (PUID), in the form of a DOI, to PGRFA at the accession level (http://www.planttreaty.org/doi). Genebanks not applying a true PUID to their accessions should use, and request recipients to use, the concatenation of INSTCODE, ACCENUMB, and GENUS as a globally unique identifier similar in most respects to the PUID whenever they exchange information on accessions with third parties (e.g. NOR017:NGB17773:ALLIUM).",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteCode": {
+                    "description": "MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. COL001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mlsStatus": {
+                    "description": "MCPD (v2.1) (MLSSTAT) 27. The status of an accession with regards to the Multilateral System (MLS) of the International Treaty on Plant Genetic Resources for Food and Agriculture. Leave the value empty if the status is not known 0 No (not included) 1 Yes (included) 99 Other (elaborate in REMARKS field, e.g. \"under development\")",
+                    "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "99"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "remarks": {
+                    "description": "MCPD (v2.1) (REMARKS) 28. The remarks field is used to add notes or to elaborate on descriptors with value 99 or 999 (= Other). Prefix remarks with the field name they refer to and a colon (:) without space (e.g. COLLSRC:riverside). Distinct remarks referring to different fields are separated by semicolons without space.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "safetyDuplicateInstitues": {
+                    "items": {
+                        "properties": {
+                            "instituteCode": {
+                                "description": "MCPD (v2.1) (DUPLSITE) 25. FAO WIEWS code of the institute(s) where a safety duplicate of the accession is maintained. Follows INSTCODE standard.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "MCPD (v2.1) (DUPLINSTNAME) 25.1  Name of the institute where a safety duplicate of the accession is maintained.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "species": {
+                    "description": "MCPD (v2.1) (SPECIES) 6. Specific epithet portion of the scientific name in lowercase letters. Only the following abbreviation is allowed: \"sp.\" ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "speciesAuthority": {
+                    "description": "MCPD (v2.1) (SPAUTHOR) 7. Provide the authority for the species name.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "storageTypeCodes": {
+                    "description": "MCPD (v2.1) (STORAGE) 26. If germplasm is maintained under different types of storage, multiple choices are allowed, separated by a semicolon (e.g. 20;30). (Refer to FAO/IPGRI Genebank Standards 1994 for details on storage type.) 10) Seed collection 11) Short term 12) Medium term 13) Long term 20) Field collection 30) In vitro collection 40) Cryopreserved collection 50) DNA collection 99) Other (elaborate in REMARKS field)",
+                    "items": {
+                        "enum": [
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                            "20",
+                            "30",
+                            "40",
+                            "50",
+                            "99"
+                        ],
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "subtaxon": {
+                    "description": "MCPD (v2.1) (SUBTAXA) 8. Subtaxon can be used to store any additional taxonomic identifier. The following abbreviations are allowed: \"subsp.\" (for subspecies); \"convar.\" (for convariety); \"var.\" (for variety); \"f.\" (for form); \"Group\" (for \"cultivar group\").",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "subtaxonAuthority": {
+                    "description": "MCPD (v2.1) (SUBTAUTHOR) 9. Provide the subtaxon authority at the most detailed taxonomic level.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "germplasmMCPD",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidMcpdResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidPedigreeResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidPedigreeResponse.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "crossingPlan": {
+                    "description": "The crossing strategy used to generate this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "crossingYear": {
+                    "description": "The year the parents were originally crossed",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "defaultDisplayName": {
+                    "description": "A human readable name for a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "familyCode": {
+                    "description": "The code representing the family",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": " The ID which uniquely identifies a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent1DbId": {
+                    "description": "The germplasm DbId of the first parent of this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent1Id": {
+                    "description": "**Deprecated** use parent1DbId",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent1Name": {
+                    "description": "the human readable name of the first parent of this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent1Type": {
+                    "description": "The type of parent the first parent is. ex. 'MALE', 'FEMALE', 'SELF', 'POPULATION', etc.",
+                    "enum": [
+                        "MALE",
+                        "FEMALE",
+                        "SELF",
+                        "POPULATION"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent2DbId": {
+                    "description": "The germplasm DbId of the second parent of this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent2Id": {
+                    "description": "**Deprecated** use parent2DbId",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent2Name": {
+                    "description": "The human readable name of the second parent of this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "parent2Type": {
+                    "description": "The type of parent the second parent is. ex. 'MALE', 'FEMALE', 'SELF', 'POPULATION', etc.",
+                    "enum": [
+                        "MALE",
+                        "FEMALE",
+                        "SELF",
+                        "POPULATION"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "pedigree": {
+                    "description": "The string representation of the pedigree.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "siblings": {
+                    "description": "List of sibling germplasm ",
+                    "items": {
+                        "properties": {
+                            "defaultDisplayName": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "pedigree",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidPedigreeResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidProgenyResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidProgenyResponse.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "defaultDisplayName": {
+                    "description": "A human readable name for a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "The ID which uniquely identifies a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "progeny": {
+                    "description": "List of germplasm entities which are direct children of this germplasm",
+                    "items": {
+                        "properties": {
+                            "defaultDisplayName": {
+                                "description": "The human readable name of a progeny germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": "The unique identifier of a progeny germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "parentType": {
+                                "description": "Given a germplasm A having a progeny B and C, 'parentType' for progeny B item refers to the 'parentType' of A toward B.",
+                                "enum": [
+                                    "MALE",
+                                    "FEMALE",
+                                    "SELF",
+                                    "POPULATION"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "progeny",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidProgenyResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmGermplasmdbidResponse.json
@@ -1,0 +1,232 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "accessionNumber": {
+                    "description": "This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "acquisitionDate": {
+                    "description": "The date this germplasm was aquired by the genebank (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "biologicalStatusOfAccessionCode": {
+                    "description": "The 3 digit code representing the biological status of the accession (MCPD)",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "breedingMethodDbId": {
+                    "description": "The unique identifier for the breeding method used to create this germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "commonCropName": {
+                    "description": "Common name for the crop (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "countryOfOriginCode": {
+                    "description": "3-letter ISO 3166-1 code of the country in which the sample was originally collected (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "defaultDisplayName": {
+                    "description": "Human readable name used for display purposes",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "donors": {
+                    "description": "List of donor institutes (MCPD)",
+                    "items": {
+                        "properties": {
+                            "donorAccessionNumber": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "donorInstituteCode": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmPUI": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "The ID which uniquely identifies a germplasm within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmGenus": {
+                    "description": "Genus name for taxon. Initial uppercase letter required. (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmName": {
+                    "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmPUI": {
+                    "description": "The Permanent Unique Identifier which represents a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "germplasmSpecies": {
+                    "description": "Specific epithet portion of the scientific name in lowercase letters. (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteCode": {
+                    "description": "The code for the Institute that has bred the material. (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteName": {
+                    "description": "The name of the institution which bred the material (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "pedigree": {
+                    "description": "The cross name and optional selection history.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "seedSource": {
+                    "description": "The source of the seed ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "speciesAuthority": {
+                    "description": "The authority organization responsible for tracking and maintaining the species name (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "subtaxa": {
+                    "description": "Subtaxon can be used to store any additional taxonomic identifier. (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "subtaxaAuthority": {
+                    "description": " The authority organization responsible for tracking and maintaining the subtaxon information (MCPD)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "synonyms": {
+                    "description": "List of alternative names or IDs used to reference this germplasm",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "taxonIds": {
+                    "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.",
+                    "items": {
+                        "properties": {
+                            "sourceName": {
+                                "description": "The human readable name of the taxonomy provider",
+                                "type": "string"
+                            },
+                            "taxonId": {
+                                "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "sourceName",
+                            "taxonId"
+                        ],
+                        "title": "taxonID",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "typeOfGermplasmStorageCode": {
+                    "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. (MCPD)",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "germplasm",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getGermplasmResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getGermplasmResponse.json
@@ -1,0 +1,244 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "accessionNumber": {
+                                "description": "This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "acquisitionDate": {
+                                "description": "The date this germplasm was aquired by the genebank (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "biologicalStatusOfAccessionCode": {
+                                "description": "The 3 digit code representing the biological status of the accession (MCPD)",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "breedingMethodDbId": {
+                                "description": "The unique identifier for the breeding method used to create this germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "countryOfOriginCode": {
+                                "description": "3-letter ISO 3166-1 code of the country in which the sample was originally collected (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultDisplayName": {
+                                "description": "Human readable name used for display purposes",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "donors": {
+                                "description": "List of donor institutes (MCPD)",
+                                "items": {
+                                    "properties": {
+                                        "donorAccessionNumber": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "donorInstituteCode": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "germplasmPUI": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": "The ID which uniquely identifies a germplasm within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmGenus": {
+                                "description": "Genus name for taxon. Initial uppercase letter required. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmPUI": {
+                                "description": "The Permanent Unique Identifier which represents a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmSpecies": {
+                                "description": "Specific epithet portion of the scientific name in lowercase letters. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteCode": {
+                                "description": "The code for the Institute that has bred the material. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which bred the material (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The cross name and optional selection history.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seedSource": {
+                                "description": "The source of the seed ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "speciesAuthority": {
+                                "description": "The authority organization responsible for tracking and maintaining the species name (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxa": {
+                                "description": "Subtaxon can be used to store any additional taxonomic identifier. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxaAuthority": {
+                                "description": " The authority organization responsible for tracking and maintaining the subtaxon information (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of alternative names or IDs used to reference this germplasm",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "taxonIds": {
+                                "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.",
+                                "items": {
+                                    "properties": {
+                                        "sourceName": {
+                                            "description": "The human readable name of the taxonomy provider",
+                                            "type": "string"
+                                        },
+                                        "taxonId": {
+                                            "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceName",
+                                        "taxonId"
+                                    ],
+                                    "title": "taxonID",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "typeOfGermplasmStorageCode": {
+                                "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. (MCPD)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "germplasm",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getSearchGermplasmSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getSearchGermplasmSearchresultsdbidResponse.json
@@ -1,0 +1,244 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "accessionNumber": {
+                                "description": "This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "acquisitionDate": {
+                                "description": "The date this germplasm was aquired by the genebank (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "biologicalStatusOfAccessionCode": {
+                                "description": "The 3 digit code representing the biological status of the accession (MCPD)",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "breedingMethodDbId": {
+                                "description": "The unique identifier for the breeding method used to create this germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "countryOfOriginCode": {
+                                "description": "3-letter ISO 3166-1 code of the country in which the sample was originally collected (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultDisplayName": {
+                                "description": "Human readable name used for display purposes",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "donors": {
+                                "description": "List of donor institutes (MCPD)",
+                                "items": {
+                                    "properties": {
+                                        "donorAccessionNumber": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "donorInstituteCode": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "germplasmPUI": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": "The ID which uniquely identifies a germplasm within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmGenus": {
+                                "description": "Genus name for taxon. Initial uppercase letter required. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmPUI": {
+                                "description": "The Permanent Unique Identifier which represents a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmSpecies": {
+                                "description": "Specific epithet portion of the scientific name in lowercase letters. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteCode": {
+                                "description": "The code for the Institute that has bred the material. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which bred the material (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The cross name and optional selection history.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seedSource": {
+                                "description": "The source of the seed ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "speciesAuthority": {
+                                "description": "The authority organization responsible for tracking and maintaining the species name (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxa": {
+                                "description": "Subtaxon can be used to store any additional taxonomic identifier. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxaAuthority": {
+                                "description": " The authority organization responsible for tracking and maintaining the subtaxon information (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of alternative names or IDs used to reference this germplasm",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "taxonIds": {
+                                "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.",
+                                "items": {
+                                    "properties": {
+                                        "sourceName": {
+                                            "description": "The human readable name of the taxonomy provider",
+                                            "type": "string"
+                                        },
+                                        "taxonId": {
+                                            "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceName",
+                                        "taxonId"
+                                    ],
+                                    "title": "taxonID",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "typeOfGermplasmStorageCode": {
+                                "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. (MCPD)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "germplasm",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchGermplasmSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/getStudiesStudydbidGermplasmResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/getStudiesStudydbidGermplasmResponse.json
@@ -1,0 +1,267 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "List of germplasm associated with a given trial and study",
+                    "items": {
+                        "properties": {
+                            "accessionNumber": {
+                                "description": "This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "acquisitionDate": {
+                                "description": "The date this germplasm was aquired by the genebank (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "biologicalStatusOfAccessionCode": {
+                                "description": "The 3 digit code representing the biological status of the accession (MCPD)",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "breedingMethodDbId": {
+                                "description": "The unique identifier for the breeding method used to create this germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "countryOfOriginCode": {
+                                "description": "3-letter ISO 3166-1 code of the country in which the sample was originally collected (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultDisplayName": {
+                                "description": "Human readable name used for display purposes",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "donors": {
+                                "description": "List of donor institutes (MCPD)",
+                                "items": {
+                                    "properties": {
+                                        "donorAccessionNumber": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "donorInstituteCode": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "germplasmPUI": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "** Deprecated ** use /studies/{studyDbId/layout for positional germplasm relationships",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "genus": {
+                                "description": "Genus name for taxon. Initial uppercase letter required. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": "The ID which uniquely identifies a germplasm within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmPUI": {
+                                "description": "The Permanent Unique Identifier which represents a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteCode": {
+                                "description": "The code for the Institute that has bred the material. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which bred the material (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The cross name and optional selection history.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seedSource": {
+                                "description": "The source of the seed ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "species": {
+                                "description": "Specific epithet portion of the scientific name in lowercase letters. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "speciesAuthority": {
+                                "description": "The authority organization responsible for tracking and maintaining the species name (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxa": {
+                                "description": "Subtaxon can be used to store any additional taxonomic identifier. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxaAuthority": {
+                                "description": " The authority organization responsible for tracking and maintaining the subtaxon information (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of alternative names or IDs used to reference this germplasm",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "taxonIds": {
+                                "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.",
+                                "items": {
+                                    "properties": {
+                                        "sourceName": {
+                                            "description": "The human readable name of the taxonomy provider",
+                                            "type": "string"
+                                        },
+                                        "taxonId": {
+                                            "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceName",
+                                        "taxonId"
+                                    ],
+                                    "title": "taxonID",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "typeOfGermplasmStorageCode": {
+                                "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. (MCPD)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "germplasmSummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "studyDbId": {
+                    "description": "** Deprecated ** The request contains the studyDbId\nThe ID which uniquely identifies a study within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "description": "** Deprecated ** trialName not relevent \nThe human readable name of a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "germplasmSummaryList",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidGermplasmResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Germplasm/postSearchGermplasmResponse.json
+++ b/src/main/resources/schemas/v1.3/Germplasm/postSearchGermplasmResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchGermplasmResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesCategoriesResponse.json
+++ b/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesCategoriesResponse.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "attributeCategoryDbId": {
+                                "description": "The ID which uniquely identifies this attribute category within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeCategoryName": {
+                                "description": "A human readable name for this attribute category. Very similar to Trait class. (examples: \"morphologic\", \"phenologic\", \"agronomic\", \"physiologic\", \"abiotic stress\", \"biotic stress\", \"biochemic\", \"quality traits\", \"fertility\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "germplasmAttributeCategory",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getAttributesCategoriesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesResponse.json
+++ b/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesResponse.json
@@ -1,0 +1,621 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "attributeCategoryDbId": {
+                                "description": "General category for the attribute. very similar to Trait class.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeDbId": {
+                                "description": "The ID which uniquely identifies this attribute within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeName": {
+                                "description": "A human readable name for this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "contextOfUse": {
+                                "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "crop": {
+                                "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultValue": {
+                                "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "A human readable description of this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "growthStage": {
+                                "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "institution": {
+                                "description": "Name of institution submitting the variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "language": {
+                                "description": "2 letter ISO code for the language of submission of the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "method": {
+                                "description": "Method metadata",
+                                "properties": {
+                                    "class": {
+                                        "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "Method description.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "formula": {
+                                        "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodDbId": {
+                                        "description": "Method unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodName": {
+                                        "description": "Human readable name for the method",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "reference": {
+                                        "description": "Bibliographical reference describing the method.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "method",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scale": {
+                                "description": "Scale metadata",
+                                "properties": {
+                                    "dataType": {
+                                        "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                        "enum": [
+                                            "Code",
+                                            "Duration",
+                                            "Nominal",
+                                            "Numerical",
+                                            "Ordinal",
+                                            "Text",
+                                            "Date"
+                                        ],
+                                        "title": "traitDataType",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "decimalPlaces": {
+                                        "description": "For numerical, number of decimal places to be reported",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "scaleDbId": {
+                                        "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "scaleName": {
+                                        "description": "Name of the scale",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "validValues": {
+                                        "properties": {
+                                            "categories": {
+                                                "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "max": {
+                                                "description": "Maximum value (used for field data capture control).",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            },
+                                            "min": {
+                                                "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            }
+                                        },
+                                        "title": "validValues",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "scale",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scientist": {
+                                "description": "Name of scientist submitting the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "status": {
+                                "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "submissionTimestamp": {
+                                "description": "Timestamp when the Variable was added (ISO 8601)",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "Other variable names",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trait": {
+                                "properties": {
+                                    "alternativeAbbreviations": {
+                                        "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "attribute": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "class": {
+                                        "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "The description of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "entity": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "mainAbbreviation": {
+                                        "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "status": {
+                                        "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "synonyms": {
+                                        "description": "Other trait names",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "traitDbId": {
+                                        "description": "The ID which uniquely identifies a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "traitName": {
+                                        "description": "The human readable name of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "trait",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "germplasmAttributeDef"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getAttributesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/GermplasmAttributes/getGermplasmGermplasmdbidAttributesResponse.json
+++ b/src/main/resources/schemas/v1.3/GermplasmAttributes/getGermplasmGermplasmdbidAttributesResponse.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "List of attributes associated with the given germplasm",
+                    "items": {
+                        "properties": {
+                            "attributeCode": {
+                                "description": "Short abbreviation which represents this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeDbId": {
+                                "description": "The ID which uniquely identifies this attribute within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "attributeName": {
+                                "description": "The human readable name of this attribute",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "determinedDate": {
+                                "description": "The date the value of this attribute was determined for a given germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "value": {
+                                "description": "The value of this attribute for a given germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "germplasmAttribute",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "germplasmDbId": {
+                    "description": "The ID which uniquely identifies a germplasm within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "germplasmAttributeList",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getGermplasmGermplasmdbidAttributesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/getImagesImagedbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getImagesImagedbidResponse.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "copyright": {
+                    "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The human readable description of an image.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "descriptiveOntologyTerms": {
+                    "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "imageDbId": {
+                    "description": "The unique identifier of an image",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileName": {
+                    "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileSize": {
+                    "description": "The size of the image in Bytes.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageHeight": {
+                    "description": "The height of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageLocation": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "properties": {
+                        "geometry": {
+                            "oneOf": [
+                                {
+                                    "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "A single position",
+                                            "items": {
+                                                "type": "number"
+                                            },
+                                            "minItems": 2,
+                                            "title": "position",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Point"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Point",
+                                    "type": "object"
+                                },
+                                {
+                                    "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "An array of linear rings",
+                                            "items": {
+                                                "description": "An array of at least four positions where the first equals the last",
+                                                "items": {
+                                                    "description": "A single position",
+                                                    "items": {
+                                                        "type": "number"
+                                                    },
+                                                    "minItems": 2,
+                                                    "title": "position",
+                                                    "type": "array"
+                                                },
+                                                "minItems": 4,
+                                                "title": "linearRing",
+                                                "type": "array"
+                                            },
+                                            "title": "polygon",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Polygon"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Polygon",
+                                    "type": "object"
+                                }
+                            ],
+                            "title": "GeoJSON Geometry",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "type": {
+                            "enum": [
+                                "Feature"
+                            ],
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "geoJSON",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "imageName": {
+                    "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageTimeStamp": {
+                    "description": "The date and time the image was taken",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageURL": {
+                    "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageWidth": {
+                    "description": "The width of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "mimeType": {
+                    "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                    "pattern": "image/.*",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationDbIds": {
+                    "description": "A list of observation Ids this image is associated with, if applicable.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationUnitDbId": {
+                    "description": "The related observation unit identifier, if relevent.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "image",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getImagesImagedbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/getImagesResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getImagesResponse.json
@@ -1,0 +1,226 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Array of image meta data",
+                    "items": {
+                        "properties": {
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "copyright": {
+                                "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "The human readable description of an image.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "descriptiveOntologyTerms": {
+                                "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "imageDbId": {
+                                "description": "The unique identifier of an image",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageFileName": {
+                                "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageFileSize": {
+                                "description": "The size of the image in Bytes.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "imageHeight": {
+                                "description": "The height of the image in Pixels.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "imageLocation": {
+                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                                "properties": {
+                                    "geometry": {
+                                        "oneOf": [
+                                            {
+                                                "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                                "properties": {
+                                                    "coordinates": {
+                                                        "description": "A single position",
+                                                        "items": {
+                                                            "type": "number"
+                                                        },
+                                                        "minItems": 2,
+                                                        "title": "position",
+                                                        "type": "array"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Point"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "title": "Point",
+                                                "type": "object"
+                                            },
+                                            {
+                                                "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                                "properties": {
+                                                    "coordinates": {
+                                                        "description": "An array of linear rings",
+                                                        "items": {
+                                                            "description": "An array of at least four positions where the first equals the last",
+                                                            "items": {
+                                                                "description": "A single position",
+                                                                "items": {
+                                                                    "type": "number"
+                                                                },
+                                                                "minItems": 2,
+                                                                "title": "position",
+                                                                "type": "array"
+                                                            },
+                                                            "minItems": 4,
+                                                            "title": "linearRing",
+                                                            "type": "array"
+                                                        },
+                                                        "title": "polygon",
+                                                        "type": "array"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Polygon"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "title": "Polygon",
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "title": "GeoJSON Geometry",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "Feature"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "geoJSON",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "imageName": {
+                                "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageTimeStamp": {
+                                "description": "The date and time the image was taken",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageURL": {
+                                "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageWidth": {
+                                "description": "The width of the image in Pixels.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "mimeType": {
+                                "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                                "pattern": "image/.*",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationDbIds": {
+                                "description": "A list of observation Ids this image is associated with, if applicable.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The related observation unit identifier, if relevent.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "image",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getImagesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/getSearchImagesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getSearchImagesSearchresultsdbidResponse.json
@@ -1,0 +1,226 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Array of image meta data",
+                    "items": {
+                        "properties": {
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "copyright": {
+                                "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "The human readable description of an image.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "descriptiveOntologyTerms": {
+                                "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "imageDbId": {
+                                "description": "The unique identifier of an image",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageFileName": {
+                                "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageFileSize": {
+                                "description": "The size of the image in Bytes.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "imageHeight": {
+                                "description": "The height of the image in Pixels.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "imageLocation": {
+                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                                "properties": {
+                                    "geometry": {
+                                        "oneOf": [
+                                            {
+                                                "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                                "properties": {
+                                                    "coordinates": {
+                                                        "description": "A single position",
+                                                        "items": {
+                                                            "type": "number"
+                                                        },
+                                                        "minItems": 2,
+                                                        "title": "position",
+                                                        "type": "array"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Point"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "title": "Point",
+                                                "type": "object"
+                                            },
+                                            {
+                                                "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                                "properties": {
+                                                    "coordinates": {
+                                                        "description": "An array of linear rings",
+                                                        "items": {
+                                                            "description": "An array of at least four positions where the first equals the last",
+                                                            "items": {
+                                                                "description": "A single position",
+                                                                "items": {
+                                                                    "type": "number"
+                                                                },
+                                                                "minItems": 2,
+                                                                "title": "position",
+                                                                "type": "array"
+                                                            },
+                                                            "minItems": 4,
+                                                            "title": "linearRing",
+                                                            "type": "array"
+                                                        },
+                                                        "title": "polygon",
+                                                        "type": "array"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "Polygon"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "title": "Polygon",
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "title": "GeoJSON Geometry",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "Feature"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "geoJSON",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "imageName": {
+                                "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageTimeStamp": {
+                                "description": "The date and time the image was taken",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageURL": {
+                                "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "imageWidth": {
+                                "description": "The width of the image in Pixels.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "mimeType": {
+                                "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                                "pattern": "image/.*",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationDbIds": {
+                                "description": "A list of observation Ids this image is associated with, if applicable.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The related observation unit identifier, if relevent.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "image",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchImagesSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/postImagesResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/postImagesResponse.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "copyright": {
+                    "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The human readable description of an image.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "descriptiveOntologyTerms": {
+                    "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "imageDbId": {
+                    "description": "The unique identifier of an image",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileName": {
+                    "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileSize": {
+                    "description": "The size of the image in Bytes.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageHeight": {
+                    "description": "The height of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageLocation": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "properties": {
+                        "geometry": {
+                            "oneOf": [
+                                {
+                                    "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "A single position",
+                                            "items": {
+                                                "type": "number"
+                                            },
+                                            "minItems": 2,
+                                            "title": "position",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Point"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Point",
+                                    "type": "object"
+                                },
+                                {
+                                    "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "An array of linear rings",
+                                            "items": {
+                                                "description": "An array of at least four positions where the first equals the last",
+                                                "items": {
+                                                    "description": "A single position",
+                                                    "items": {
+                                                        "type": "number"
+                                                    },
+                                                    "minItems": 2,
+                                                    "title": "position",
+                                                    "type": "array"
+                                                },
+                                                "minItems": 4,
+                                                "title": "linearRing",
+                                                "type": "array"
+                                            },
+                                            "title": "polygon",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Polygon"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Polygon",
+                                    "type": "object"
+                                }
+                            ],
+                            "title": "GeoJSON Geometry",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "type": {
+                            "enum": [
+                                "Feature"
+                            ],
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "geoJSON",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "imageName": {
+                    "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageTimeStamp": {
+                    "description": "The date and time the image was taken",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageURL": {
+                    "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageWidth": {
+                    "description": "The width of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "mimeType": {
+                    "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                    "pattern": "image/.*",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationDbIds": {
+                    "description": "A list of observation Ids this image is associated with, if applicable.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationUnitDbId": {
+                    "description": "The related observation unit identifier, if relevent.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "image",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postImagesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/postSearchImagesResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/postSearchImagesResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchImagesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/putImagesImagedbidImagecontentResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/putImagesImagedbidImagecontentResponse.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "copyright": {
+                    "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The human readable description of an image.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "descriptiveOntologyTerms": {
+                    "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "imageDbId": {
+                    "description": "The unique identifier of an image",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileName": {
+                    "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileSize": {
+                    "description": "The size of the image in Bytes.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageHeight": {
+                    "description": "The height of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageLocation": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "properties": {
+                        "geometry": {
+                            "oneOf": [
+                                {
+                                    "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "A single position",
+                                            "items": {
+                                                "type": "number"
+                                            },
+                                            "minItems": 2,
+                                            "title": "position",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Point"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Point",
+                                    "type": "object"
+                                },
+                                {
+                                    "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "An array of linear rings",
+                                            "items": {
+                                                "description": "An array of at least four positions where the first equals the last",
+                                                "items": {
+                                                    "description": "A single position",
+                                                    "items": {
+                                                        "type": "number"
+                                                    },
+                                                    "minItems": 2,
+                                                    "title": "position",
+                                                    "type": "array"
+                                                },
+                                                "minItems": 4,
+                                                "title": "linearRing",
+                                                "type": "array"
+                                            },
+                                            "title": "polygon",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Polygon"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Polygon",
+                                    "type": "object"
+                                }
+                            ],
+                            "title": "GeoJSON Geometry",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "type": {
+                            "enum": [
+                                "Feature"
+                            ],
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "geoJSON",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "imageName": {
+                    "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageTimeStamp": {
+                    "description": "The date and time the image was taken",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageURL": {
+                    "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageWidth": {
+                    "description": "The width of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "mimeType": {
+                    "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                    "pattern": "image/.*",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationDbIds": {
+                    "description": "A list of observation Ids this image is associated with, if applicable.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationUnitDbId": {
+                    "description": "The related observation unit identifier, if relevent.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "image",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putImagesImagedbidImagecontentResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Images/putImagesImagedbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/putImagesImagedbidResponse.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "copyright": {
+                    "description": "The copyright information of this image. Example 'Copyright 2018 Bob Robertson'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The human readable description of an image.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "descriptiveOntologyTerms": {
+                    "description": "A list of terms to formally describe the image. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "imageDbId": {
+                    "description": "The unique identifier of an image",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileName": {
+                    "description": "The name of the image file. Might be the same as 'imageName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageFileSize": {
+                    "description": "The size of the image in Bytes.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageHeight": {
+                    "description": "The height of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "imageLocation": {
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "properties": {
+                        "geometry": {
+                            "oneOf": [
+                                {
+                                    "description": "Example \n\n    [ -76.506042, 42.417373 ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "A single position",
+                                            "items": {
+                                                "type": "number"
+                                            },
+                                            "minItems": 2,
+                                            "title": "position",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Point"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Point",
+                                    "type": "object"
+                                },
+                                {
+                                    "description": "Example \n\n    [ \n    \n      [ \n      \n        [ -77.456654, 42.241133 ], \n        \n        [ -75.414133, 41.508282 ],\n      \n        [ -76.506042, 42.417373 ], \n        \n        [ -77.456654, 42.241133 ] \n      \n      ] \n    \n    ]",
+                                    "properties": {
+                                        "coordinates": {
+                                            "description": "An array of linear rings",
+                                            "items": {
+                                                "description": "An array of at least four positions where the first equals the last",
+                                                "items": {
+                                                    "description": "A single position",
+                                                    "items": {
+                                                        "type": "number"
+                                                    },
+                                                    "minItems": 2,
+                                                    "title": "position",
+                                                    "type": "array"
+                                                },
+                                                "minItems": 4,
+                                                "title": "linearRing",
+                                                "type": "array"
+                                            },
+                                            "title": "polygon",
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "enum": [
+                                                "Polygon"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": "Polygon",
+                                    "type": "object"
+                                }
+                            ],
+                            "title": "GeoJSON Geometry",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "type": {
+                            "enum": [
+                                "Feature"
+                            ],
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "geoJSON",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "imageName": {
+                    "description": "The human readable name of an image. Might be the same as 'imageFileName', but could be different.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageTimeStamp": {
+                    "description": "The date and time the image was taken",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageURL": {
+                    "description": "The complete, absolute URI path to the image file. Images might be stored on a different host or path than the BrAPI web server.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "imageWidth": {
+                    "description": "The width of the image in Pixels.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "mimeType": {
+                    "description": "The file type of the image. Examples 'image/jpeg', 'image/png', 'image/svg', etc",
+                    "pattern": "image/.*",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationDbIds": {
+                    "description": "A list of observation Ids this image is associated with, if applicable.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationUnitDbId": {
+                    "description": "The related observation unit identifier, if relevent.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "image",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putImagesImagedbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Lists/getListsListdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Lists/getListsListdbidResponse.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dateCreated": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dateModified": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerPersonDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listSize": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "listSource": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listType": {
+                    "enum": [
+                        "germplasm",
+                        "markers",
+                        "programs",
+                        "trials",
+                        "studies",
+                        "observationUnits",
+                        "observations",
+                        "observationVariables",
+                        "samples"
+                    ],
+                    "title": "listTypes",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "listDetails"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getListsListdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Lists/getListsResponse.json
+++ b/src/main/resources/schemas/v1.3/Lists/getListsResponse.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Array of generic list summaries",
+                    "items": {
+                        "properties": {
+                            "dateCreated": {
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "dateModified": {
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "listDbId": {
+                                "type": "string"
+                            },
+                            "listName": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "listOwnerName": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "listOwnerPersonDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "listSize": {
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "listSource": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "listType": {
+                                "enum": [
+                                    "germplasm",
+                                    "markers",
+                                    "programs",
+                                    "trials",
+                                    "studies",
+                                    "observationUnits",
+                                    "observations",
+                                    "observationVariables",
+                                    "samples"
+                                ],
+                                "title": "listTypes",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "listDbId",
+                            "listType"
+                        ],
+                        "title": "listSummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getListsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Lists/postListsListdbidItemsResponse.json
+++ b/src/main/resources/schemas/v1.3/Lists/postListsListdbidItemsResponse.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dateCreated": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dateModified": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerPersonDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listSize": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "listSource": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listType": {
+                    "enum": [
+                        "germplasm",
+                        "markers",
+                        "programs",
+                        "trials",
+                        "studies",
+                        "observationUnits",
+                        "observations",
+                        "observationVariables",
+                        "samples"
+                    ],
+                    "title": "listTypes",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "listDetails"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postListsListdbidItemsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Lists/postListsResponse.json
+++ b/src/main/resources/schemas/v1.3/Lists/postListsResponse.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dateCreated": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dateModified": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerPersonDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listSize": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "listSource": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listType": {
+                    "enum": [
+                        "germplasm",
+                        "markers",
+                        "programs",
+                        "trials",
+                        "studies",
+                        "observationUnits",
+                        "observations",
+                        "observationVariables",
+                        "samples"
+                    ],
+                    "title": "listTypes",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "listDetails"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postListsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Lists/putListsListdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Lists/putListsListdbidResponse.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dateCreated": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "dateModified": {
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listOwnerPersonDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listSize": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "listSource": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "listType": {
+                    "enum": [
+                        "germplasm",
+                        "markers",
+                        "programs",
+                        "trials",
+                        "studies",
+                        "observationUnits",
+                        "observations",
+                        "observationVariables",
+                        "samples"
+                    ],
+                    "title": "listTypes",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "listDetails"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putListsListdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Locations/getLocationsLocationdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Locations/getLocationsLocationdbidResponse.json
@@ -1,0 +1,125 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "abbreviation": {
+                    "description": "An abbreviation which represents this location",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "abreviation": {
+                    "description": "Deprecated  Use abbreviation ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Additional arbitrary info",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "altitude": {
+                    "description": "The altitude of this location",
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                },
+                "countryCode": {
+                    "description": "[ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "countryName": {
+                    "description": "The full name of the country where this location is",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteAddress": {
+                    "description": "The street address of the institute representing this location",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteAdress": {
+                    "description": "Deprecated  Use instituteAddress ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "instituteName": {
+                    "description": "each institute/laboratory can have several experimental field",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "latitude": {
+                    "description": "The latitude of this location",
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                },
+                "locationDbId": {
+                    "description": "string identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "locationName": {
+                    "description": "A human readable name for this location",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "locationType": {
+                    "description": "The type of location this represents (ex. Breeding Location, Storage Location, etc)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "longitude": {
+                    "description": "the longitude of this location",
+                    "type": [
+                        "null",
+                        "number"
+                    ]
+                }
+            },
+            "title": "location",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getLocationsLocationdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Locations/getLocationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Locations/getLocationsResponse.json
@@ -1,0 +1,137 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "abbreviation": {
+                                "description": "An abbreviation which represents this location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "abreviation": {
+                                "description": "Deprecated  Use abbreviation ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "altitude": {
+                                "description": "The altitude of this location",
+                                "type": [
+                                    "null",
+                                    "number"
+                                ]
+                            },
+                            "countryCode": {
+                                "description": "[ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "countryName": {
+                                "description": "The full name of the country where this location is",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteAddress": {
+                                "description": "The street address of the institute representing this location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteAdress": {
+                                "description": "Deprecated  Use instituteAddress ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "each institute/laboratory can have several experimental field",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "latitude": {
+                                "description": "The latitude of this location",
+                                "type": [
+                                    "null",
+                                    "number"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "string identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "A human readable name for this location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationType": {
+                                "description": "The type of location this represents (ex. Breeding Location, Storage Location, etc)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "longitude": {
+                                "description": "the longitude of this location",
+                                "type": [
+                                    "null",
+                                    "number"
+                                ]
+                            }
+                        },
+                        "title": "location",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getLocationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/MarkerProfiles/getAllelematrices-searchResponse.json
+++ b/src/main/resources/schemas/v1.3/MarkerProfiles/getAllelematrices-searchResponse.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Is an array of arrays; each inner array has three entries: ```markerDbId```, ```markerProfileDbId```, ```alleleCall```. Scores have to be represented as described further up. e.g. unknown data as \"N\", etc. Missing data can be skipped.",
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "alleleMatrixValues",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getAllelematrices-searchResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/MarkerProfiles/getAllelematricesResponse.json
+++ b/src/main/resources/schemas/v1.3/MarkerProfiles/getAllelematricesResponse.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "description": {
+                                "description": "How the matrix was generated",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "lastUpdated": {
+                                "description": "A date format",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "matrixDbId": {
+                                "description": "ID of the matrix",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "matrixName": {
+                                "description": "Name of the matrix",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "Link to the study where the matrix was produced",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "alleleMatrixDetails",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getAllelematricesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/MarkerProfiles/getMarkerprofilesMarkerprofiledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/MarkerProfiles/getMarkerprofilesMarkerprofiledbidResponse.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "analysisMethod": {
+                    "description": "The type of analysis performed to determine a set of marker data",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "data": {
+                    "description": "array of marker-name/score pairs",
+                    "items": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "extractDbId": {
+                    "description": "Required",
+                    "type": "string"
+                },
+                "germplasmDbId": {
+                    "description": "Required",
+                    "type": "string"
+                },
+                "markerProfileDbId": {
+                    "description": "Unique in the database. Can be a catenation of unique IDs for germplasm and extract. Required",
+                    "type": "string"
+                },
+                "markerprofileDbId": {
+                    "description": "DEPRECATED in v1.3 - see \"markerProfileDbId\" (camel case)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "uniqueDisplayName": {
+                    "description": "Human readable display name for this marker profile",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "data",
+                "extractDbId",
+                "germplasmDbId",
+                "markerProfileDbId"
+            ],
+            "title": "markerProfile",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMarkerprofilesMarkerprofiledbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/MarkerProfiles/getMarkerprofilesResponse.json
+++ b/src/main/resources/schemas/v1.3/MarkerProfiles/getMarkerprofilesResponse.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "analysisMethod": {
+                                "description": "The type of analysis performed to determine a set of marker data",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "extractDbId": {
+                                "description": " The ID which uniquely identifies this data extract",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerProfileDbId": {
+                                "description": "Unique in the database. Can be a catenation of unique IDs for germplasm and extract. Required",
+                                "type": "string"
+                            },
+                            "markerprofileDbId": {
+                                "description": "DEPRECATED in v1.3 - see \"markerProfileDbId\" (camel case)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "resultCount": {
+                                "description": "Number of markers present in the marker profile",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "sampleDbId": {
+                                "description": "The ID which uniquely identifies a sample",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "uniqueDisplayName": {
+                                "description": "Human readable display name for this marker profile",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "markerProfileDbId"
+                        ],
+                        "title": "markerProfileDescription",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMarkerprofilesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/MarkerProfiles/postAllelematrices-searchResponse.json
+++ b/src/main/resources/schemas/v1.3/MarkerProfiles/postAllelematrices-searchResponse.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Is an array of arrays; each inner array has three entries: ```markerDbId```, ```markerProfileDbId```, ```alleleCall```. Scores have to be represented as described further up. e.g. unknown data as \"N\", etc. Missing data can be skipped.",
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "alleleMatrixValues",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postAllelematrices-searchResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Markers/getMarkersMarkerdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Markers/getMarkersMarkerdbidResponse.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "analysisMethods": {
+                    "description": "List of the genotyping platforms used to interrogate the marker",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "markerDbId": {
+                    "description": "Internal db identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "markerName": {
+                    "description": "A string representing the marker that will be meaningful to the user",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "refAlt": {
+                    "description": "List of the reference (as the first item) and alternatives (the remaining items)",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "synonyms": {
+                    "description": "List of other names for this marker",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "type": {
+                    "description": "The type of marker, e.g. SNP",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "marker",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMarkersMarkerdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Markers/getMarkersResponse.json
+++ b/src/main/resources/schemas/v1.3/Markers/getMarkersResponse.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "analysisMethods": {
+                                "description": "List of the genotyping platforms used to interrogate the marker",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "markerDbId": {
+                                "description": "Internal db identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerName": {
+                                "description": "A string representing the marker that will be meaningful to the user",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "refAlt": {
+                                "description": "List of the reference (as the first item) and alternatives (the remaining items)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of other names for this marker",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of marker, e.g. SNP",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "marker",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMarkersResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Markers/getSearchMarkersSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Markers/getSearchMarkersSearchresultsdbidResponse.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "analysisMethods": {
+                                "description": "List of the genotyping platforms used to interrogate the marker",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "markerDbId": {
+                                "description": "Internal db identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "markerName": {
+                                "description": "A string representing the marker that will be meaningful to the user",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "refAlt": {
+                                "description": "List of the reference (as the first item) and alternatives (the remaining items)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of other names for this marker",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of marker, e.g. SNP",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "marker",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchMarkersSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Markers/postSearchMarkersResponse.json
+++ b/src/main/resources/schemas/v1.3/Markers/postSearchMarkersResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchMarkersResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsMethoddbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsMethoddbidResponse.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Method metadata",
+            "properties": {
+                "class": {
+                    "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                    "title": "className",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "Method description.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "formula": {
+                    "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodDbId": {
+                    "description": "Method unique identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodName": {
+                    "description": "Human readable name for the method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "reference": {
+                    "description": "Bibliographical reference describing the method.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "method",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMethodsMethoddbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsResponse.json
@@ -1,0 +1,132 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "description": "Method metadata",
+                        "properties": {
+                            "class": {
+                                "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                "title": "className",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "Method description.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "formula": {
+                                "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "methodDbId": {
+                                "description": "Method unique identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "methodName": {
+                                "description": "Human readable name for the method",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "reference": {
+                                "description": "Bibliographical reference describing the method.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "method",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getMethodsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getOntologiesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getOntologiesResponse.json
@@ -1,0 +1,83 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "authors": {
+                                "description": "Ontology's list of authors (no specific format)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "copyright": {
+                                "description": "Ontology copyright",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "Human readable description of Ontology",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "licence": {
+                                "description": "Ontology licence",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyDbId": {
+                                "description": "Ontology database unique identifier",
+                                "type": "string"
+                            },
+                            "ontologyName": {
+                                "description": "Ontology name",
+                                "type": "string"
+                            },
+                            "version": {
+                                "description": "Ontology version (no specific format)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "ontologyDbId",
+                            "ontologyName"
+                        ],
+                        "title": "ontology",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getOntologiesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getScalesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getScalesResponse.json
@@ -1,0 +1,167 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "description": "Scale metadata",
+                        "properties": {
+                            "dataType": {
+                                "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                "enum": [
+                                    "Code",
+                                    "Duration",
+                                    "Nominal",
+                                    "Numerical",
+                                    "Ordinal",
+                                    "Text",
+                                    "Date"
+                                ],
+                                "title": "traitDataType",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "decimalPlaces": {
+                                "description": "For numerical, number of decimal places to be reported",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scaleDbId": {
+                                "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "scaleName": {
+                                "description": "Name of the scale",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "validValues": {
+                                "properties": {
+                                    "categories": {
+                                        "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "max": {
+                                        "description": "Maximum value (used for field data capture control).",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "min": {
+                                        "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    }
+                                },
+                                "title": "validValues",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "scale",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getScalesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getScalesScaledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getScalesScaledbidResponse.json
@@ -1,0 +1,155 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Scale metadata",
+            "properties": {
+                "dataType": {
+                    "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                    "enum": [
+                        "Code",
+                        "Duration",
+                        "Nominal",
+                        "Numerical",
+                        "Ordinal",
+                        "Text",
+                        "Date"
+                    ],
+                    "title": "traitDataType",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "decimalPlaces": {
+                    "description": "For numerical, number of decimal places to be reported",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "scaleDbId": {
+                    "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "scaleName": {
+                    "description": "Name of the scale",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "validValues": {
+                    "properties": {
+                        "categories": {
+                            "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "max": {
+                            "description": "Maximum value (used for field data capture control).",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "min": {
+                            "description": "Minimum value (used for data capture control) for numerical and date scales",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        }
+                    },
+                    "title": "validValues",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "scale",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getScalesScaledbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getSearchVariablesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getSearchVariablesSearchresultsdbidResponse.json
@@ -1,0 +1,607 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "contextOfUse": {
+                                "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "crop": {
+                                "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultValue": {
+                                "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "growthStage": {
+                                "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "institution": {
+                                "description": "Name of institution submitting the variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "language": {
+                                "description": "2 letter ISO code for the language of submission of the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "method": {
+                                "description": "Method metadata",
+                                "properties": {
+                                    "class": {
+                                        "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "Method description.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "formula": {
+                                        "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodDbId": {
+                                        "description": "Method unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodName": {
+                                        "description": "Human readable name for the method",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "reference": {
+                                        "description": "Bibliographical reference describing the method.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "method",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "Variable unique identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "Variable name (usually a short name)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scale": {
+                                "description": "Scale metadata",
+                                "properties": {
+                                    "dataType": {
+                                        "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                        "enum": [
+                                            "Code",
+                                            "Duration",
+                                            "Nominal",
+                                            "Numerical",
+                                            "Ordinal",
+                                            "Text",
+                                            "Date"
+                                        ],
+                                        "title": "traitDataType",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "decimalPlaces": {
+                                        "description": "For numerical, number of decimal places to be reported",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "scaleDbId": {
+                                        "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "scaleName": {
+                                        "description": "Name of the scale",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "validValues": {
+                                        "properties": {
+                                            "categories": {
+                                                "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "max": {
+                                                "description": "Maximum value (used for field data capture control).",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            },
+                                            "min": {
+                                                "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            }
+                                        },
+                                        "title": "validValues",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "scale",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scientist": {
+                                "description": "Name of scientist submitting the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "status": {
+                                "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "submissionTimestamp": {
+                                "description": "Timestamp when the Variable was added (ISO 8601)",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "Other variable names",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trait": {
+                                "properties": {
+                                    "alternativeAbbreviations": {
+                                        "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "attribute": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "class": {
+                                        "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "The description of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "entity": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "mainAbbreviation": {
+                                        "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "status": {
+                                        "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "synonyms": {
+                                        "description": "Other trait names",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "traitDbId": {
+                                        "description": "The ID which uniquely identifies a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "traitName": {
+                                        "description": "The human readable name of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "trait",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationVariable"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchVariablesSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getStudiesStudydbidObservationvariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getStudiesStudydbidObservationvariablesResponse.json
@@ -1,0 +1,619 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "contextOfUse": {
+                                "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "crop": {
+                                "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultValue": {
+                                "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "growthStage": {
+                                "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "institution": {
+                                "description": "Name of institution submitting the variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "language": {
+                                "description": "2 letter ISO code for the language of submission of the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "method": {
+                                "description": "Method metadata",
+                                "properties": {
+                                    "class": {
+                                        "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "Method description.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "formula": {
+                                        "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodDbId": {
+                                        "description": "Method unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodName": {
+                                        "description": "Human readable name for the method",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "reference": {
+                                        "description": "Bibliographical reference describing the method.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "method",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "Variable unique identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "Variable name (usually a short name)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scale": {
+                                "description": "Scale metadata",
+                                "properties": {
+                                    "dataType": {
+                                        "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                        "enum": [
+                                            "Code",
+                                            "Duration",
+                                            "Nominal",
+                                            "Numerical",
+                                            "Ordinal",
+                                            "Text",
+                                            "Date"
+                                        ],
+                                        "title": "traitDataType",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "decimalPlaces": {
+                                        "description": "For numerical, number of decimal places to be reported",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "scaleDbId": {
+                                        "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "scaleName": {
+                                        "description": "Name of the scale",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "validValues": {
+                                        "properties": {
+                                            "categories": {
+                                                "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "max": {
+                                                "description": "Maximum value (used for field data capture control).",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            },
+                                            "min": {
+                                                "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            }
+                                        },
+                                        "title": "validValues",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "scale",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scientist": {
+                                "description": "Name of scientist submitting the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "status": {
+                                "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "submissionTimestamp": {
+                                "description": "Timestamp when the Variable was added (ISO 8601)",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "Other variable names",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trait": {
+                                "properties": {
+                                    "alternativeAbbreviations": {
+                                        "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "attribute": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "class": {
+                                        "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "The description of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "entity": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "mainAbbreviation": {
+                                        "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "status": {
+                                        "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "synonyms": {
+                                        "description": "Other trait names",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "traitDbId": {
+                                        "description": "The ID which uniquely identifies a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "traitName": {
+                                        "description": "The human readable name of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "trait",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationVariable"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "studyDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationvariablesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getTraitsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getTraitsResponse.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "defaultValue": {
+                                "description": "The default value of a trait (if applicable) ex. \"0\", \"\", \"null\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "description": {
+                                "description": "The description of a trait",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariables": {
+                                "description": "List of observation variable DbIds which include this trait",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "traitDbId": {
+                                "description": "The ID which uniquely identifies a trait",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "traitName": {
+                                "description": "The human readable name of a trait",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "traitSummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getTraitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getTraitsTraitdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getTraitsTraitdbidResponse.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "defaultValue": {
+                    "description": "The default value of a trait (if applicable) ex. \"0\", \"\", \"null\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The description of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationVariables": {
+                    "description": "List of observation variable DbIds which include this trait",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "traitDbId": {
+                    "description": "The ID which uniquely identifies a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "traitName": {
+                    "description": "The human readable name of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "traitSummary",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getTraitsTraitdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse.json
@@ -1,0 +1,595 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "contextOfUse": {
+                    "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "crop": {
+                    "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "defaultValue": {
+                    "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "growthStage": {
+                    "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "institution": {
+                    "description": "Name of institution submitting the variable",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "language": {
+                    "description": "2 letter ISO code for the language of submission of the variable.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "method": {
+                    "description": "Method metadata",
+                    "properties": {
+                        "class": {
+                            "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                            "title": "className",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "description": {
+                            "description": "Method description.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "formula": {
+                            "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "methodDbId": {
+                            "description": "Method unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "methodName": {
+                            "description": "Human readable name for the method",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyRefernce": {
+                            "properties": {
+                                "documentationLinks": {
+                                    "description": "links to various ontology documentation",
+                                    "items": {
+                                        "properties": {
+                                            "URL": {
+                                                "format": "uri",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "type": {
+                                                "enum": [
+                                                    "OBO",
+                                                    "RDF",
+                                                    "WEBPAGE"
+                                                ],
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": [
+                                        "null",
+                                        "array"
+                                    ]
+                                },
+                                "ontologyDbId": {
+                                    "description": "Ontology database unique identifier",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "ontologyName": {
+                                    "description": "Ontology name",
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "description": "Ontology version (no specific format)",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "ontologyName"
+                            ],
+                            "title": "ontologyRefernce",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "reference": {
+                            "description": "Bibliographical reference describing the method.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "method",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "observationVariableDbId": {
+                    "description": "Variable unique identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationVariableName": {
+                    "description": "Variable name (usually a short name)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "scale": {
+                    "description": "Scale metadata",
+                    "properties": {
+                        "dataType": {
+                            "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                            "enum": [
+                                "Code",
+                                "Duration",
+                                "Nominal",
+                                "Numerical",
+                                "Ordinal",
+                                "Text",
+                                "Date"
+                            ],
+                            "title": "traitDataType",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "decimalPlaces": {
+                            "description": "For numerical, number of decimal places to be reported",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "ontologyRefernce": {
+                            "properties": {
+                                "documentationLinks": {
+                                    "description": "links to various ontology documentation",
+                                    "items": {
+                                        "properties": {
+                                            "URL": {
+                                                "format": "uri",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "type": {
+                                                "enum": [
+                                                    "OBO",
+                                                    "RDF",
+                                                    "WEBPAGE"
+                                                ],
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": [
+                                        "null",
+                                        "array"
+                                    ]
+                                },
+                                "ontologyDbId": {
+                                    "description": "Ontology database unique identifier",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "ontologyName": {
+                                    "description": "Ontology name",
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "description": "Ontology version (no specific format)",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "ontologyName"
+                            ],
+                            "title": "ontologyRefernce",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "scaleDbId": {
+                            "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "scaleName": {
+                            "description": "Name of the scale",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "validValues": {
+                            "properties": {
+                                "categories": {
+                                    "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": [
+                                        "null",
+                                        "array"
+                                    ]
+                                },
+                                "max": {
+                                    "description": "Maximum value (used for field data capture control).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "min": {
+                                    "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                }
+                            },
+                            "title": "validValues",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "xref": {
+                            "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "scale",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "scientist": {
+                    "description": "Name of scientist submitting the variable.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "status": {
+                    "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "submissionTimestamp": {
+                    "description": "Timestamp when the Variable was added (ISO 8601)",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "synonyms": {
+                    "description": "Other variable names",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "trait": {
+                    "properties": {
+                        "alternativeAbbreviations": {
+                            "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "attribute": {
+                            "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "class": {
+                            "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                            "title": "className",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "description": {
+                            "description": "The description of a trait",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "entity": {
+                            "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "mainAbbreviation": {
+                            "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyRefernce": {
+                            "properties": {
+                                "documentationLinks": {
+                                    "description": "links to various ontology documentation",
+                                    "items": {
+                                        "properties": {
+                                            "URL": {
+                                                "format": "uri",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "type": {
+                                                "enum": [
+                                                    "OBO",
+                                                    "RDF",
+                                                    "WEBPAGE"
+                                                ],
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "type": [
+                                        "null",
+                                        "array"
+                                    ]
+                                },
+                                "ontologyDbId": {
+                                    "description": "Ontology database unique identifier",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "ontologyName": {
+                                    "description": "Ontology name",
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "description": "Ontology version (no specific format)",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "ontologyName"
+                            ],
+                            "title": "ontologyRefernce",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "status": {
+                            "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "synonyms": {
+                            "description": "Other trait names",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "traitDbId": {
+                            "description": "The ID which uniquely identifies a trait",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "traitName": {
+                            "description": "The human readable name of a trait",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "xref": {
+                            "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "trait",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "observationVariable"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVariablesObservationvariabledbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesResponse.json
@@ -1,0 +1,607 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "contextOfUse": {
+                                "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "crop": {
+                                "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultValue": {
+                                "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "growthStage": {
+                                "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "institution": {
+                                "description": "Name of institution submitting the variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "language": {
+                                "description": "2 letter ISO code for the language of submission of the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "method": {
+                                "description": "Method metadata",
+                                "properties": {
+                                    "class": {
+                                        "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "Method description.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "formula": {
+                                        "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodDbId": {
+                                        "description": "Method unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodName": {
+                                        "description": "Human readable name for the method",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "reference": {
+                                        "description": "Bibliographical reference describing the method.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "method",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "Variable unique identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "Variable name (usually a short name)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scale": {
+                                "description": "Scale metadata",
+                                "properties": {
+                                    "dataType": {
+                                        "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                        "enum": [
+                                            "Code",
+                                            "Duration",
+                                            "Nominal",
+                                            "Numerical",
+                                            "Ordinal",
+                                            "Text",
+                                            "Date"
+                                        ],
+                                        "title": "traitDataType",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "decimalPlaces": {
+                                        "description": "For numerical, number of decimal places to be reported",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "scaleDbId": {
+                                        "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "scaleName": {
+                                        "description": "Name of the scale",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "validValues": {
+                                        "properties": {
+                                            "categories": {
+                                                "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "max": {
+                                                "description": "Maximum value (used for field data capture control).",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            },
+                                            "min": {
+                                                "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            }
+                                        },
+                                        "title": "validValues",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "scale",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scientist": {
+                                "description": "Name of scientist submitting the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "status": {
+                                "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "submissionTimestamp": {
+                                "description": "Timestamp when the Variable was added (ISO 8601)",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "Other variable names",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trait": {
+                                "properties": {
+                                    "alternativeAbbreviations": {
+                                        "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "attribute": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "class": {
+                                        "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "The description of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "entity": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "mainAbbreviation": {
+                                        "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "status": {
+                                        "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "synonyms": {
+                                        "description": "Other trait names",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "traitDbId": {
+                                        "description": "The ID which uniquely identifies a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "traitName": {
+                                        "description": "The human readable name of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "trait",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationVariable"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVariablesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postMethodsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postMethodsResponse.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Method metadata",
+            "properties": {
+                "class": {
+                    "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                    "title": "className",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "Method description.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "formula": {
+                    "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodDbId": {
+                    "description": "Method unique identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodName": {
+                    "description": "Human readable name for the method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "reference": {
+                    "description": "Bibliographical reference describing the method.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "method",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postMethodsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postScalesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postScalesResponse.json
@@ -1,0 +1,155 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Scale metadata",
+            "properties": {
+                "dataType": {
+                    "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                    "enum": [
+                        "Code",
+                        "Duration",
+                        "Nominal",
+                        "Numerical",
+                        "Ordinal",
+                        "Text",
+                        "Date"
+                    ],
+                    "title": "traitDataType",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "decimalPlaces": {
+                    "description": "For numerical, number of decimal places to be reported",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "scaleDbId": {
+                    "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "scaleName": {
+                    "description": "Name of the scale",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "validValues": {
+                    "properties": {
+                        "categories": {
+                            "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "max": {
+                            "description": "Maximum value (used for field data capture control).",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "min": {
+                            "description": "Minimum value (used for data capture control) for numerical and date scales",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        }
+                    },
+                    "title": "validValues",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "scale",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postScalesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postSearchVariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postSearchVariablesResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchVariablesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postTraitsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postTraitsResponse.json
@@ -1,0 +1,160 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "alternativeAbbreviations": {
+                    "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "attribute": {
+                    "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "class": {
+                    "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                    "title": "className",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The description of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "entity": {
+                    "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mainAbbreviation": {
+                    "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "status": {
+                    "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "synonyms": {
+                    "description": "Other trait names",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "traitDbId": {
+                    "description": "The ID which uniquely identifies a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "traitName": {
+                    "description": "The human readable name of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "trait",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postTraitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putMethodsMethoddbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putMethodsMethoddbidResponse.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Method metadata",
+            "properties": {
+                "class": {
+                    "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                    "title": "className",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "Method description.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "formula": {
+                    "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodDbId": {
+                    "description": "Method unique identifier",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "methodName": {
+                    "description": "Human readable name for the method",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "reference": {
+                    "description": "Bibliographical reference describing the method.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "method",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putMethodsMethoddbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putScalesScaledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putScalesScaledbidResponse.json
@@ -1,0 +1,155 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Scale metadata",
+            "properties": {
+                "dataType": {
+                    "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                    "enum": [
+                        "Code",
+                        "Duration",
+                        "Nominal",
+                        "Numerical",
+                        "Ordinal",
+                        "Text",
+                        "Date"
+                    ],
+                    "title": "traitDataType",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "decimalPlaces": {
+                    "description": "For numerical, number of decimal places to be reported",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "scaleDbId": {
+                    "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "scaleName": {
+                    "description": "Name of the scale",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "validValues": {
+                    "properties": {
+                        "categories": {
+                            "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "max": {
+                            "description": "Maximum value (used for field data capture control).",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "min": {
+                            "description": "Minimum value (used for data capture control) for numerical and date scales",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        }
+                    },
+                    "title": "validValues",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "scale",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putScalesScaledbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putTraitsTraitdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putTraitsTraitdbidResponse.json
@@ -1,0 +1,160 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "alternativeAbbreviations": {
+                    "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "attribute": {
+                    "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "class": {
+                    "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                    "title": "className",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "description": {
+                    "description": "The description of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "entity": {
+                    "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mainAbbreviation": {
+                    "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "ontologyRefernce": {
+                    "properties": {
+                        "documentationLinks": {
+                            "description": "links to various ontology documentation",
+                            "items": {
+                                "properties": {
+                                    "URL": {
+                                        "format": "uri",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "OBO",
+                                            "RDF",
+                                            "WEBPAGE"
+                                        ],
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "ontologyDbId": {
+                            "description": "Ontology database unique identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "ontologyName": {
+                            "description": "Ontology name",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "Ontology version (no specific format)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "ontologyName"
+                    ],
+                    "title": "ontologyRefernce",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "status": {
+                    "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "synonyms": {
+                    "description": "Other trait names",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "traitDbId": {
+                    "description": "The ID which uniquely identifies a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "traitName": {
+                    "description": "The human readable name of a trait",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "xref": {
+                    "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "trait",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putTraitsTraitdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getObservationlevelsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getObservationlevelsResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "description": "observation levels available in this database",
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getObservationlevelsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getObservationunitsResponse.json
@@ -1,0 +1,312 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "The entry number for an observation unit. Different systems may use different entry systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevels": {
+                                "description": "Concatenation of the levels of this observationUnit. Used to handle non canonical level structures. Format levelType:levelID,levelType:levelID",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitXref": {
+                                "description": "A list of external references to this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "description": "The unique ID in the external reference 'source' system",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "source": {
+                                            "description": "The system identifier (name, URL, etc) which has an external reference to the observation unit",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationUnitXref",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observations": {
+                                "description": "List of observations associated with this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "collector": {
+                                            "description": "The name or identifier of the entity which collected the observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationDbId": {
+                                            "description": "The ID which uniquely identifies an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationTimeStamp": {
+                                            "description": "The date and time  when this observation was made ",
+                                            "format": "date-time",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableDbId": {
+                                            "description": "The ID which uniquely identifies an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableName": {
+                                            "description": "A human readable name for an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "season": {
+                                            "description": "The season when the observation data was collected",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the data collected as an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationSummaryPhenotype",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "plantNumber": {
+                                "description": "The plant number in a field. Applicable for observationLevel: \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plotNumber": {
+                                "description": "The plot number in a field. Applicable for observationLevel: \"plot\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The human readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyLocation": {
+                                "description": "The human readable name of a location associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyLocationDbId": {
+                                "description": "The ID which uniquely identifies a location, associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The human readable name for a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "treatments": {
+                                "description": "List of treatments applied to an observation unit.",
+                                "items": {
+                                    "properties": {
+                                        "factor": {
+                                            "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "modality": {
+                                            "description": "The treatment/factor descritpion. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationTreatment",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "observationUnitPhenotype",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getSearchObservationtablesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getSearchObservationtablesSearchresultsdbidResponse.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Matrix of observation meta-data and recorded values. Each inner array represents 1 row of data.",
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "headerRow": {
+                    "description": "Names of the columns included in the data matrix. Any or All of [ \"year\",\"studyDbId\",\"studyName\",\"locationDbId\",\"locationName\",\"germplasmDbId\",\"germplasmName\",\"observationUnitDbId\",\"plotNumber\",\"replicate\",\"blockNumber\", \"entryType\", \"X\", \"Y\"]",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableDbIds": {
+                    "description": "Array of observation variable DbIds for the collected data. This array is appended to the \"headerRow\" to get the complete header of the data matrix",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableNames": {
+                    "description": "Human readable names of the observation variables for the collected data. This array should match 1 to 1 with the \"observationVariableDbIds\" array.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "observationUnitsTableResponse",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchObservationtablesSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getSearchObservationunitsSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getSearchObservationunitsSearchresultsdbidResponse.json
@@ -1,0 +1,363 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "The entry number for an observation unit. Different systems may use different entry systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "The ID which uniquely identifies a location, associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "The human readable name of a location associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevels": {
+                                "description": "Concatenation of the levels of this observationUnit. Used to handle non canonical level structures. Format levelType:levelID,levelType:levelID",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitXref": {
+                                "description": "A list of external references to this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "description": "The unique ID in the external reference 'source' system",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "source": {
+                                            "description": "The system identifier (name, URL, etc) which has an external reference to the observation unit",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationUnitXref",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observations": {
+                                "description": "List of observations associated with this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "collector": {
+                                            "description": "The name or identifier of the entity which collected the observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationDbId": {
+                                            "description": "The ID which uniquely identifies an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationTimeStamp": {
+                                            "description": "The date and time  when this observation was made ",
+                                            "format": "date-time",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableDbId": {
+                                            "description": "The ID which uniquely identifies an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableName": {
+                                            "description": "A human readable name for an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "season": {
+                                            "properties": {
+                                                "season": {
+                                                    "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "seasonDbId": {
+                                                    "description": "The ID which uniquely identifies a season",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "year": {
+                                                    "description": "The 4 digit year of the season.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "season",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the data collected as an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationSummary",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The string representation of the pedigree of this observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plantNumber": {
+                                "description": "The plant number in a field. Applicable for observationLevel: \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plotNumber": {
+                                "description": "The plot number in a field. Applicable for observationLevel: \"plot\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The human readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The human readable name for a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "treatments": {
+                                "description": "List of treatments applied to an observation unit.",
+                                "items": {
+                                    "properties": {
+                                        "factor": {
+                                            "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "modality": {
+                                            "description": "The treatment/factor descritpion. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationTreatment",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationUnit",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchObservationunitsSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidObservationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidObservationsResponse.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationDbId": {
+                                "description": "The ID which uniquely identifies an observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationTimeStamp": {
+                                "description": "The date and time  when this observation was made ",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "The ID which uniquely identifies an observation variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "A human readable name for an observation variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "operator": {
+                                "description": "The name or identifier of the entity which collected the observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "season": {
+                                "properties": {
+                                    "season": {
+                                        "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "seasonDbId": {
+                                        "description": "The ID which uniquely identifies a season",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "year": {
+                                        "description": "The 4 digit year of the season.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "season",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "uploadedBy": {
+                                "description": "The name or id of the user who uploaded the observation to the database system",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "value": {
+                                "description": "The value of the data collected as an observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observation",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidObservationunitsResponse.json
@@ -1,0 +1,363 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "The entry number for an observation unit. Different systems may use different entry systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "The ID which uniquely identifies a location, associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "The human readable name of a location associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevels": {
+                                "description": "Concatenation of the levels of this observationUnit. Used to handle non canonical level structures. Format levelType:levelID,levelType:levelID",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitXref": {
+                                "description": "A list of external references to this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "description": "The unique ID in the external reference 'source' system",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "source": {
+                                            "description": "The system identifier (name, URL, etc) which has an external reference to the observation unit",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationUnitXref",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observations": {
+                                "description": "List of observations associated with this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "collector": {
+                                            "description": "The name or identifier of the entity which collected the observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationDbId": {
+                                            "description": "The ID which uniquely identifies an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationTimeStamp": {
+                                            "description": "The date and time  when this observation was made ",
+                                            "format": "date-time",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableDbId": {
+                                            "description": "The ID which uniquely identifies an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableName": {
+                                            "description": "A human readable name for an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "season": {
+                                            "properties": {
+                                                "season": {
+                                                    "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "seasonDbId": {
+                                                    "description": "The ID which uniquely identifies a season",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "year": {
+                                                    "description": "The 4 digit year of the season.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "season",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the data collected as an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationSummary",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The string representation of the pedigree of this observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plantNumber": {
+                                "description": "The plant number in a field. Applicable for observationLevel: \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plotNumber": {
+                                "description": "The plot number in a field. Applicable for observationLevel: \"plot\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The human readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The human readable name for a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "treatments": {
+                                "description": "List of treatments applied to an observation unit.",
+                                "items": {
+                                    "properties": {
+                                        "factor": {
+                                            "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "modality": {
+                                            "description": "The treatment/factor descritpion. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationTreatment",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationUnit",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidTableResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/getStudiesStudydbidTableResponse.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Matrix of observation data recorded for different observation variables across different observation units",
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "headerRow": {
+                    "description": "The header row describing observation unit fields. Append 'observationVariableDbIds' for complete header row of the table.\nThis array should contain any or all of the following strings; year, studyDbId, studyName, locationDbId, locationName, germplasmDbId, germplasmName, observationUnitDbId, plotNumber, replicate, blockNumber, observationTimestamp (DEPRECATED in V1.3), entryType, X, Y",
+                    "items": {
+                        "description": "valid header fields",
+                        "enum": [
+                            "year",
+                            "studyDbId",
+                            "studyName",
+                            "locationDbId",
+                            "locationName",
+                            "germplasmDbId",
+                            "germplasmName",
+                            "observationUnitDbId",
+                            "plotNumber",
+                            "replicate",
+                            "blockNumber",
+                            "observationTimestamp",
+                            "entryType",
+                            "X",
+                            "Y"
+                        ],
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableDbIds": {
+                    "description": "The list of observation variables which have values recorded for them in the data matrix. Append to the 'headerRow' for comlete header row.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableNames": {
+                    "description": "The list of observation variable names which have values recorded for them in the data matrix. Order should match 'observationVariableDbIds'.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "observationsTable",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidTableResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/postPhenotypesResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/postPhenotypesResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postPhenotypesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/postSearchObservationtablesResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/postSearchObservationtablesResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchObservationtablesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/postSearchObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/postSearchObservationunitsResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/postStudiesStudydbidObservationunitsZipResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/postStudiesStudydbidObservationunitsZipResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observationUnitDbIds": {
+                    "description": "List of observation unit references which have been created or updated",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationUnitDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postStudiesStudydbidObservationunitsZipResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/postStudiesStudydbidTableResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/postStudiesStudydbidTableResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postStudiesStudydbidTableResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/putStudiesStudydbidObservationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/putStudiesStudydbidObservationsResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putStudiesStudydbidObservationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Observations/putStudiesStudydbidObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Observations/putStudiesStudydbidObservationunitsResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observationUnitDbIds": {
+                    "description": "List of observation unit references which have been created or updated",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationUnitDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putStudiesStudydbidObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/People/getPeoplePersondbidResponse.json
+++ b/src/main/resources/schemas/v1.3/People/getPeoplePersondbidResponse.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "description": {
+                    "description": "description of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "emailAddress": {
+                    "description": "email address for this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "firstName": {
+                    "description": "Persons first name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastName": {
+                    "description": "Persons last name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mailingAddress": {
+                    "description": "physical address of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "middleName": {
+                    "description": "Persons middle name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "personDbId": {
+                    "description": "Unique ID for this person",
+                    "type": "string"
+                },
+                "phoneNumber": {
+                    "description": "phone number of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "userID": {
+                    "description": "A systems user ID ascociated with this person. Different from personDbId because you could have a person who is not a user of the system.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "personDbId"
+            ],
+            "title": "person",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getPeoplePersondbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/People/getPeopleResponse.json
+++ b/src/main/resources/schemas/v1.3/People/getPeopleResponse.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Array of people",
+                    "items": {
+                        "properties": {
+                            "description": {
+                                "description": "description of this person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "emailAddress": {
+                                "description": "email address for this person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "firstName": {
+                                "description": "Persons first name",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "lastName": {
+                                "description": "Persons last name",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "mailingAddress": {
+                                "description": "physical address of this person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "middleName": {
+                                "description": "Persons middle name",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "personDbId": {
+                                "description": "Unique ID for this person",
+                                "type": "string"
+                            },
+                            "phoneNumber": {
+                                "description": "phone number of this person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "userID": {
+                                "description": "A systems user ID ascociated with this person. Different from personDbId because you could have a person who is not a user of the system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "personDbId"
+                        ],
+                        "title": "person",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getPeopleResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/People/postPeopleResponse.json
+++ b/src/main/resources/schemas/v1.3/People/postPeopleResponse.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "description": {
+                    "description": "description of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "emailAddress": {
+                    "description": "email address for this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "firstName": {
+                    "description": "Persons first name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastName": {
+                    "description": "Persons last name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mailingAddress": {
+                    "description": "physical address of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "middleName": {
+                    "description": "Persons middle name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "personDbId": {
+                    "description": "Unique ID for this person",
+                    "type": "string"
+                },
+                "phoneNumber": {
+                    "description": "phone number of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "userID": {
+                    "description": "A systems user ID ascociated with this person. Different from personDbId because you could have a person who is not a user of the system.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "personDbId"
+            ],
+            "title": "person",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postPeopleResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/People/putPeoplePersondbidResponse.json
+++ b/src/main/resources/schemas/v1.3/People/putPeoplePersondbidResponse.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "description": {
+                    "description": "description of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "emailAddress": {
+                    "description": "email address for this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "firstName": {
+                    "description": "Persons first name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastName": {
+                    "description": "Persons last name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "mailingAddress": {
+                    "description": "physical address of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "middleName": {
+                    "description": "Persons middle name",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "personDbId": {
+                    "description": "Unique ID for this person",
+                    "type": "string"
+                },
+                "phoneNumber": {
+                    "description": "phone number of this person",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "userID": {
+                    "description": "A systems user ID ascociated with this person. Different from personDbId because you could have a person who is not a user of the system.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "personDbId"
+            ],
+            "title": "person",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putPeoplePersondbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Phenotypes/postPhenotypesResponse.json
+++ b/src/main/resources/schemas/v1.3/Phenotypes/postPhenotypesResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postPhenotypesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Programs/getProgramsResponse.json
+++ b/src/main/resources/schemas/v1.3/Programs/getProgramsResponse.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "abbreviation": {
+                                "description": "An abbreviation which represnts this program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop which this program is for",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "leadPersonDbId": {
+                                "description": "The unique identifier of the program leader",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "leadPersonName": {
+                                "description": "The name of the program leader",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "objective": {
+                                "description": "The primary objective of the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "Human readable name of the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "program",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getProgramsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Programs/getSearchProgramsSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Programs/getSearchProgramsSearchresultsdbidResponse.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "abbreviation": {
+                                "description": "An abbreviation which represnts this program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop which this program is for",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "leadPersonDbId": {
+                                "description": "The unique identifier of the program leader",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "leadPersonName": {
+                                "description": "The name of the program leader",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "objective": {
+                                "description": "The primary objective of the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "Human readable name of the program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "program",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchProgramsSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Programs/postSearchProgramsResponse.json
+++ b/src/main/resources/schemas/v1.3/Programs/postSearchProgramsResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchProgramsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Samples/getSamplesResponse.json
+++ b/src/main/resources/schemas/v1.3/Samples/getSamplesResponse.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "notes": {
+                                "description": "Additional notes about a samle",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plantDbId": {
+                                "description": "The ID which uniquely identifies a plant. Usually 'plantNumber'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plateDbId": {
+                                "description": "The ID which uniquely identifies a plate of samples",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plateIndex": {
+                                "description": "The index number of this sample on a plate",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "plotDbId": {
+                                "description": " The ID which uniquely identifies a plot. Usually 'plotNumber'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleDbId": {
+                                "description": "The ID which uniquely identifies a sample",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleTimestamp": {
+                                "description": "The date and time a sample was collected from the field",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleType": {
+                                "description": "The type of sample taken. ex. 'DNA', 'RNA', 'Tissue', etc ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "takenBy": {
+                                "description": "The name or identifier of the entity which took the sample from the field",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "tissueType": {
+                                "description": "The type of tissue sampled. ex. 'Leaf', 'Root', etc.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "sample",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSamplesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Samples/getSamplesSampledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Samples/getSamplesSampledbidResponse.json
@@ -1,0 +1,108 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "germplasmDbId": {
+                    "description": " The ID which uniquely identifies a germplasm",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "notes": {
+                    "description": "Additional notes about a samle",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "observationUnitDbId": {
+                    "description": "The ID which uniquely identifies an observation unit",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "plantDbId": {
+                    "description": "The ID which uniquely identifies a plant. Usually 'plantNumber'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "plateDbId": {
+                    "description": "The ID which uniquely identifies a plate of samples",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "plateIndex": {
+                    "description": "The index number of this sample on a plate",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "plotDbId": {
+                    "description": " The ID which uniquely identifies a plot. Usually 'plotNumber'",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sampleDbId": {
+                    "description": "The ID which uniquely identifies a sample",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sampleTimestamp": {
+                    "description": "The date and time a sample was collected from the field",
+                    "format": "date-time",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sampleType": {
+                    "description": "The type of sample taken. ex. 'DNA', 'RNA', 'Tissue', etc ",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyDbId": {
+                    "description": "The ID which uniquely identifies a study within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "takenBy": {
+                    "description": "The name or identifier of the entity which took the sample from the field",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "tissueType": {
+                    "description": "The type of tissue sampled. ex. 'Leaf', 'Root', etc.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "sample",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSamplesSampledbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Samples/getSearchSamplesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Samples/getSearchSamplesSearchresultsdbidResponse.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "notes": {
+                                "description": "Additional notes about a samle",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plantDbId": {
+                                "description": "The ID which uniquely identifies a plant. Usually 'plantNumber'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plateDbId": {
+                                "description": "The ID which uniquely identifies a plate of samples",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plateIndex": {
+                                "description": "The index number of this sample on a plate",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "plotDbId": {
+                                "description": " The ID which uniquely identifies a plot. Usually 'plotNumber'",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleDbId": {
+                                "description": "The ID which uniquely identifies a sample",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleTimestamp": {
+                                "description": "The date and time a sample was collected from the field",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleType": {
+                                "description": "The type of sample taken. ex. 'DNA', 'RNA', 'Tissue', etc ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "takenBy": {
+                                "description": "The name or identifier of the entity which took the sample from the field",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "tissueType": {
+                                "description": "The type of tissue sampled. ex. 'Leaf', 'Root', etc.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "sample",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchSamplesSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Samples/postSearchSamplesResponse.json
+++ b/src/main/resources/schemas/v1.3/Samples/postSearchSamplesResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchSamplesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Samples/putSamplesResponse.json
+++ b/src/main/resources/schemas/v1.3/Samples/putSamplesResponse.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "List of sample references which have been created or updated",
+            "properties": {
+                "sampleDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "sampleId": {
+                    "description": "** Deprecated ** use sampleDbId",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putSamplesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getSearchStudiesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getSearchStudiesSearchresultsdbidResponse.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "active": {
+                                "description": "Is this study currently active",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "endDate": {
+                                "description": "The date the study ends",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "The ID which uniquely identifies a location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "The human readable name for a location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The humane readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seasons": {
+                                "description": "List of seasons over which this study was performed.",
+                                "items": {
+                                    "properties": {
+                                        "season": {
+                                            "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "seasonDbId": {
+                                            "description": "The ID which uniquely identifies a season",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "year": {
+                                            "description": "The 4 digit year of the season.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "season",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "startDate": {
+                                "description": "The date this study started",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The humane readable name of a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeDbId": {
+                                "description": "The unique identifier of the type of study being performed.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeName": {
+                                "description": "The name of the type of study being performed. ex. \"Yield Trial\", etc",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "studySummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSearchStudiesSearchresultsdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getSeasonsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getSeasonsResponse.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "season": {
+                                "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seasonDbId": {
+                                "description": "The ID which uniquely identifies a season",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "year": {
+                                "description": "The 4 digit year of the season.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "season",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getSeasonsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesResponse.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "active": {
+                                "description": "Is this study currently active",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "endDate": {
+                                "description": "The date the study ends",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "The ID which uniquely identifies a location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "The human readable name for a location",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The humane readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seasons": {
+                                "description": "List of seasons over which this study was performed.",
+                                "items": {
+                                    "properties": {
+                                        "season": {
+                                            "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "seasonDbId": {
+                                            "description": "The ID which uniquely identifies a season",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "year": {
+                                            "description": "The 4 digit year of the season.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "season",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "startDate": {
+                                "description": "The date this study started",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The humane readable name of a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeDbId": {
+                                "description": "The unique identifier of the type of study being performed.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeName": {
+                                "description": "The name of the type of study being performed. ex. \"Yield Trial\", etc",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "studySummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidGermplasmResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidGermplasmResponse.json
@@ -1,0 +1,267 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "List of germplasm associated with a given trial and study",
+                    "items": {
+                        "properties": {
+                            "accessionNumber": {
+                                "description": "This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "acquisitionDate": {
+                                "description": "The date this germplasm was aquired by the genebank (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "biologicalStatusOfAccessionCode": {
+                                "description": "The 3 digit code representing the biological status of the accession (MCPD)",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "breedingMethodDbId": {
+                                "description": "The unique identifier for the breeding method used to create this germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "countryOfOriginCode": {
+                                "description": "3-letter ISO 3166-1 code of the country in which the sample was originally collected (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultDisplayName": {
+                                "description": "Human readable name used for display purposes",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "donors": {
+                                "description": "List of donor institutes (MCPD)",
+                                "items": {
+                                    "properties": {
+                                        "donorAccessionNumber": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "donorInstituteCode": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "germplasmPUI": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "** Deprecated ** use /studies/{studyDbId/layout for positional germplasm relationships",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "genus": {
+                                "description": "Genus name for taxon. Initial uppercase letter required. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": "The ID which uniquely identifies a germplasm within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmPUI": {
+                                "description": "The Permanent Unique Identifier which represents a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteCode": {
+                                "description": "The code for the Institute that has bred the material. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which bred the material (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The cross name and optional selection history.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "seedSource": {
+                                "description": "The source of the seed ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "species": {
+                                "description": "Specific epithet portion of the scientific name in lowercase letters. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "speciesAuthority": {
+                                "description": "The authority organization responsible for tracking and maintaining the species name (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxa": {
+                                "description": "Subtaxon can be used to store any additional taxonomic identifier. (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "subtaxaAuthority": {
+                                "description": " The authority organization responsible for tracking and maintaining the subtaxon information (MCPD)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "List of alternative names or IDs used to reference this germplasm",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "taxonIds": {
+                                "description": "The list of IDs for this SPECIES from different sources. If present, NCBI Taxon should be always listed as \"ncbiTaxon\" preferably with a purl. The rank of this ID should be species.",
+                                "items": {
+                                    "properties": {
+                                        "sourceName": {
+                                            "description": "The human readable name of the taxonomy provider",
+                                            "type": "string"
+                                        },
+                                        "taxonId": {
+                                            "description": "The identifier (name, ID, URI) of a particular taxonomy within the source provider",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "sourceName",
+                                        "taxonId"
+                                    ],
+                                    "title": "taxonID",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "typeOfGermplasmStorageCode": {
+                                "description": "The 2 digit code representing the type of storage this germplasm is kept in at a genebank. (MCPD)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "germplasmSummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "studyDbId": {
+                    "description": "** Deprecated ** The request contains the studyDbId\nThe ID which uniquely identifies a study within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "description": "** Deprecated ** trialName not relevent \nThe human readable name of a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "germplasmSummaryList",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidGermplasmResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidLayoutsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidLayoutsResponse.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "enum": [
+                                    "CHECK",
+                                    "TEST",
+                                    "FILLER"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationUnitPosition",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidLayoutsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationsResponse.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationDbId": {
+                                "description": "The ID which uniquely identifies an observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationTimeStamp": {
+                                "description": "The date and time  when this observation was made ",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "The ID which uniquely identifies an observation variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "A human readable name for an observation variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "operator": {
+                                "description": "The name or identifier of the entity which collected the observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "season": {
+                                "properties": {
+                                    "season": {
+                                        "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "seasonDbId": {
+                                        "description": "The ID which uniquely identifies a season",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "year": {
+                                        "description": "The 4 digit year of the season.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "season",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "uploadedBy": {
+                                "description": "The name or id of the user who uploaded the observation to the database system",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "value": {
+                                "description": "The value of the data collected as an observation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observation",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationunitsResponse.json
@@ -1,0 +1,363 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryNumber": {
+                                "description": "The entry number for an observation unit. Different systems may use different entry systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationDbId": {
+                                "description": "The ID which uniquely identifies a location, associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "description": "The human readable name of a location associated with this study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevels": {
+                                "description": "Concatenation of the levels of this observationUnit. Used to handle non canonical level structures. Format levelType:levelID,levelType:levelID",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitXref": {
+                                "description": "A list of external references to this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "id": {
+                                            "description": "The unique ID in the external reference 'source' system",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "source": {
+                                            "description": "The system identifier (name, URL, etc) which has an external reference to the observation unit",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationUnitXref",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "observations": {
+                                "description": "List of observations associated with this observation unit",
+                                "items": {
+                                    "properties": {
+                                        "collector": {
+                                            "description": "The name or identifier of the entity which collected the observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationDbId": {
+                                            "description": "The ID which uniquely identifies an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationTimeStamp": {
+                                            "description": "The date and time  when this observation was made ",
+                                            "format": "date-time",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableDbId": {
+                                            "description": "The ID which uniquely identifies an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "observationVariableName": {
+                                            "description": "A human readable name for an observation variable",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "season": {
+                                            "properties": {
+                                                "season": {
+                                                    "description": "Name of the season. ex. 'Spring', 'Q2', 'Season A', etc.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "seasonDbId": {
+                                                    "description": "The ID which uniquely identifies a season",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "year": {
+                                                    "description": "The 4 digit year of the season.",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "season",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "value": {
+                                            "description": "The value of the data collected as an observation",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationSummary",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "pedigree": {
+                                "description": "The string representation of the pedigree of this observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plantNumber": {
+                                "description": "The plant number in a field. Applicable for observationLevel: \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "plotNumber": {
+                                "description": "The plot number in a field. Applicable for observationLevel: \"plot\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The human readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "description": "The human readable name for a study",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "treatments": {
+                                "description": "List of treatments applied to an observation unit.",
+                                "items": {
+                                    "properties": {
+                                        "factor": {
+                                            "description": "The type of treatment/factor. ex. 'fertilizer', 'inoculation', 'irrigation', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "modality": {
+                                            "description": "The treatment/factor descritpion. ex. 'low fertilizer', 'yellow rust inoculation', 'high water', etc",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "observationTreatment",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationUnit",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationvariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationvariablesResponse.json
@@ -1,0 +1,619 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "contextOfUse": {
+                                "description": "Indication of how trait is routinely used. (examples: [\"Trial evaluation\", \"Nursery evaluation\"])",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "crop": {
+                                "description": "Crop name (examples: \"Maize\", \"Wheat\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "defaultValue": {
+                                "description": "Variable default value. (examples: \"red\", \"2.3\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "growthStage": {
+                                "description": "Growth stage at which measurement is made (examples: \"flowering\")",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "institution": {
+                                "description": "Name of institution submitting the variable",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "language": {
+                                "description": "2 letter ISO code for the language of submission of the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "method": {
+                                "description": "Method metadata",
+                                "properties": {
+                                    "class": {
+                                        "description": "Method class (examples: \"Measurement\", \"Counting\", \"Estimation\", \"Computation\", etc.",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "Method description.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "formula": {
+                                        "description": "For computational methods i.e., when the method consists in assessing the trait by computing measurements, write the generic formula used for the calculation",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodDbId": {
+                                        "description": "Method unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "methodName": {
+                                        "description": "Human readable name for the method",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "reference": {
+                                        "description": "Bibliographical reference describing the method.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "method",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "description": "Variable unique identifier",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableName": {
+                                "description": "Variable name (usually a short name)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "ontologyRefernce": {
+                                "properties": {
+                                    "documentationLinks": {
+                                        "description": "links to various ontology documentation",
+                                        "items": {
+                                            "properties": {
+                                                "URL": {
+                                                    "format": "uri",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "type": {
+                                                    "enum": [
+                                                        "OBO",
+                                                        "RDF",
+                                                        "WEBPAGE"
+                                                    ],
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "ontologyDbId": {
+                                        "description": "Ontology database unique identifier",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyName": {
+                                        "description": "Ontology name",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "Ontology version (no specific format)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "ontologyName"
+                                ],
+                                "title": "ontologyRefernce",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scale": {
+                                "description": "Scale metadata",
+                                "properties": {
+                                    "dataType": {
+                                        "description": "Class of the scale, entries can be \n\n  \"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal\n            scale that combines the expressions of the different traits composing the complex\n            trait. For exemple a severity trait might be expressed by a 2 digit and 2 character\n            code. The first 2 digits are the percentage of the plant covered by a fungus and the 2\n            characters refer to the delay in development, e.g. \"75VD\" means \"75%\" of the plant is \n            Crop Ontology & Integrated Breeding Platform | Curation Guidelines | 5/6/2016 9\n            infected and the plant is very delayed.\n  \n  \"Date\" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy\n  \n  \"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months\n  \n  \"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories\n  \n  \"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches\n  \n  \"Ordinal\" - Ordinal scales are scales composed of ordered categories\n  \n  \"Text\" - A free text is used to express the trait.\n  ",
+                                        "enum": [
+                                            "Code",
+                                            "Duration",
+                                            "Nominal",
+                                            "Numerical",
+                                            "Ordinal",
+                                            "Text",
+                                            "Date"
+                                        ],
+                                        "title": "traitDataType",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "decimalPlaces": {
+                                        "description": "For numerical, number of decimal places to be reported",
+                                        "type": [
+                                            "null",
+                                            "integer"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "scaleDbId": {
+                                        "description": "Unique identifier of the scale. If left blank, the upload system will automatically generate a scale ID.",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "scaleName": {
+                                        "description": "Name of the scale",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "validValues": {
+                                        "properties": {
+                                            "categories": {
+                                                "description": "List of possible values and their meaning (examples: [\"0=low\", \"1=medium\", \"2=high\"]",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "max": {
+                                                "description": "Maximum value (used for field data capture control).",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            },
+                                            "min": {
+                                                "description": "Minimum value (used for data capture control) for numerical and date scales",
+                                                "type": [
+                                                    "null",
+                                                    "integer"
+                                                ]
+                                            }
+                                        },
+                                        "title": "validValues",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference to the scale, for example to a unit ontology such as UO or to a unit of an external major database",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "scale",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "scientist": {
+                                "description": "Name of scientist submitting the variable.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "status": {
+                                "description": "Variable status. (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "submissionTimestamp": {
+                                "description": "Timestamp when the Variable was added (ISO 8601)",
+                                "format": "date-time",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "synonyms": {
+                                "description": "Other variable names",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trait": {
+                                "properties": {
+                                    "alternativeAbbreviations": {
+                                        "description": "Other frequent abbreviations of the trait, if any. These abbreviations do not have to follow a convention",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "attribute": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "class": {
+                                        "description": "Trait class. (examples: \"morphological trait\", \"phenological trait\", \"agronomical trait\", \"physiological trait\", \"abiotic stress trait\", \"biotic stress trait\", \"biochemical trait\", \"quality traits trait\", \"fertility trait\", etc.)",
+                                        "title": "className",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "description": {
+                                        "description": "The description of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "entity": {
+                                        "description": "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "mainAbbreviation": {
+                                        "description": "Main abbreviation for trait name. (examples: \"Carotenoid content\" => \"CC\")",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "ontologyRefernce": {
+                                        "properties": {
+                                            "documentationLinks": {
+                                                "description": "links to various ontology documentation",
+                                                "items": {
+                                                    "properties": {
+                                                        "URL": {
+                                                            "format": "uri",
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        },
+                                                        "type": {
+                                                            "enum": [
+                                                                "OBO",
+                                                                "RDF",
+                                                                "WEBPAGE"
+                                                            ],
+                                                            "type": [
+                                                                "null",
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": [
+                                                    "null",
+                                                    "array"
+                                                ]
+                                            },
+                                            "ontologyDbId": {
+                                                "description": "Ontology database unique identifier",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            },
+                                            "ontologyName": {
+                                                "description": "Ontology name",
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "description": "Ontology version (no specific format)",
+                                                "type": [
+                                                    "null",
+                                                    "string"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "ontologyName"
+                                        ],
+                                        "title": "ontologyRefernce",
+                                        "type": [
+                                            "null",
+                                            "object"
+                                        ]
+                                    },
+                                    "status": {
+                                        "description": "Trait status (examples: \"recommended\", \"obsolete\", \"legacy\", etc.)",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "synonyms": {
+                                        "description": "Other trait names",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": [
+                                            "null",
+                                            "array"
+                                        ]
+                                    },
+                                    "traitDbId": {
+                                        "description": "The ID which uniquely identifies a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "traitName": {
+                                        "description": "The human readable name of a trait",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    },
+                                    "xref": {
+                                        "description": "Cross reference of the trait to an external ontology or database term e.g., Xref to a trait ontology (TO) term",
+                                        "type": [
+                                            "null",
+                                            "string"
+                                        ]
+                                    }
+                                },
+                                "title": "trait",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "xref": {
+                                "description": "Cross reference of the variable term to a term from an external ontology or to a database of a major system.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationVariable"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "studyDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidObservationvariablesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidResponse.json
@@ -1,0 +1,357 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "active": {
+                    "description": "Is this study currently active",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Additional arbitrary info",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "commonCropName": {
+                    "description": "Common name for the crop associated with this study",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "contacts": {
+                    "description": "List of contact entities associated with this study",
+                    "items": {
+                        "properties": {
+                            "contactDbId": {
+                                "description": "The ID which uniquely identifies this contact",
+                                "type": "string"
+                            },
+                            "email": {
+                                "description": "The contacts email address ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which this contact is part of",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "name": {
+                                "description": "The full name of this contact person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "orcid": {
+                                "description": "The Open Researcher and Contributor ID for this contact person (orcid.org)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of person this contact represents (ex: Coordinator, Scientist, PI, etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "contactDbId"
+                        ],
+                        "title": "contact",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "dataLinks": {
+                    "description": "List of links to extra data files associated with this study. Extra data could include notes, images, and reference data.",
+                    "items": {
+                        "properties": {
+                            "dataLinkName": {
+                                "description": "The name of the external data link",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of external data link",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "url": {
+                                "description": "The URL which links to external data",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "dataLink",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "endDate": {
+                    "description": "The date the study ends",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "lastUpdate": {
+                    "description": "The date and time when this study was last modified",
+                    "properties": {
+                        "timestamp": {
+                            "format": "date-time",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "version": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "license": {
+                    "description": "The usage license associated with the study data",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "location": {
+                    "properties": {
+                        "abbreviation": {
+                            "description": "An abbreviation which represents this location",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "abreviation": {
+                            "description": "Deprecated  Use abbreviation ",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "additionalInfo": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Additional arbitrary info",
+                            "type": [
+                                "null",
+                                "object"
+                            ]
+                        },
+                        "altitude": {
+                            "description": "The altitude of this location",
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        },
+                        "countryCode": {
+                            "description": "[ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "countryName": {
+                            "description": "The full name of the country where this location is",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "documentationURL": {
+                            "description": "A URL to the human readable documentation of this object",
+                            "format": "uri",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "instituteAddress": {
+                            "description": "The street address of the institute representing this location",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "instituteAdress": {
+                            "description": "Deprecated  Use instituteAddress ",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "instituteName": {
+                            "description": "each institute/laboratory can have several experimental field",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "latitude": {
+                            "description": "The latitude of this location",
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        },
+                        "locationDbId": {
+                            "description": "string identifier",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "locationName": {
+                            "description": "A human readable name for this location",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "locationType": {
+                            "description": "The type of location this represents (ex. Breeding Location, Storage Location, etc)",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "longitude": {
+                            "description": "the longitude of this location",
+                            "type": [
+                                "null",
+                                "number"
+                            ]
+                        }
+                    },
+                    "title": "location",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "seasons": {
+                    "description": "List of seasons over which this study was performed.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "startDate": {
+                    "description": "The date this study started",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyDbId": {
+                    "description": "The ID which uniquely identifies a study within the given database server",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyDescription": {
+                    "description": "The description of this study",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyName": {
+                    "description": "The human readable name for a study",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyTypeDbId": {
+                    "description": "The unique identifier of the type of study being performed.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studyTypeName": {
+                    "description": "The name of the type of study being performed. ex. \"Yield Trial\", etc",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialDbId": {
+                    "description": "The ID which uniquely identifies a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "description": "The human readable name of a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "study",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidTableResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidTableResponse.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "description": "Matrix of observation data recorded for different observation variables across different observation units",
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "minItems": 1,
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "headerRow": {
+                    "description": "The header row describing observation unit fields. Append 'observationVariableDbIds' for complete header row of the table.\nThis array should contain any or all of the following strings; year, studyDbId, studyName, locationDbId, locationName, germplasmDbId, germplasmName, observationUnitDbId, plotNumber, replicate, blockNumber, observationTimestamp (DEPRECATED in V1.3), entryType, X, Y",
+                    "items": {
+                        "description": "valid header fields",
+                        "enum": [
+                            "year",
+                            "studyDbId",
+                            "studyName",
+                            "locationDbId",
+                            "locationName",
+                            "germplasmDbId",
+                            "germplasmName",
+                            "observationUnitDbId",
+                            "plotNumber",
+                            "replicate",
+                            "blockNumber",
+                            "observationTimestamp",
+                            "entryType",
+                            "X",
+                            "Y"
+                        ],
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableDbIds": {
+                    "description": "The list of observation variables which have values recorded for them in the data matrix. Append to the 'headerRow' for comlete header row.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "observationVariableNames": {
+                    "description": "The list of observation variable names which have values recorded for them in the data matrix. Order should match 'observationVariableDbIds'.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "observationsTable",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudiesStudydbidTableResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/getStudytypesResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudytypesResponse.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "description": {
+                                "description": "The description of this study type",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeDbId": {
+                                "description": "The unique identifier of a study type",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyTypeName": {
+                                "description": "The human readable name of a study type",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "studyType",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getStudytypesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/postSearchStudiesResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/postSearchStudiesResponse.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "searchResultDbId": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postSearchStudiesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/postStudiesStudydbidObservationunitsZipResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/postStudiesStudydbidObservationunitsZipResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observationUnitDbIds": {
+                    "description": "List of observation unit references which have been created or updated",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationUnitDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postStudiesStudydbidObservationunitsZipResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/postStudiesStudydbidTableResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/postStudiesStudydbidTableResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postStudiesStudydbidTableResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidLayoutsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidLayoutsResponse.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "blockNumber": {
+                                "description": "The block number for an observation unit. Different systems may use different block designs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "entryType": {
+                                "description": "The type of entry for this observation unit. ex. \"check\", \"test\", \"filler\"",
+                                "enum": [
+                                    "CHECK",
+                                    "TEST",
+                                    "FILLER"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmDbId": {
+                                "description": " The ID which uniquely identifies a germplasm",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "germplasmName": {
+                                "description": "Name of the germplasm. It can be the prefered name and does not have to be unique.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationLevel": {
+                                "description": "The level of an observation unit. ex. \"plot\", \"plant\"",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "description": "The ID which uniquely identifies an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitName": {
+                                "description": "A human readable name for an observation unit",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateX": {
+                                "description": "The X position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateXType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateY": {
+                                "description": "The Y position coordinate for an observation unit. Different systems may use different coordinate systems.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "positionCoordinateYType": {
+                                "description": "The type of positional coordinate used. Must be one of the following values\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See \"Location Coordinate Encoding\" for details\nPLANTED_ROW - The physical planted row number \nPLANTED_INDIVIDUAl - The physical counted number, could be independant or within a planted row\nGRID_ROW - The row index number of a square grid overlay\nGRID_COL - The column index number of a square grid overlay\nMEASURED_ROW - The distance in meters from a defined 0th row\nMEASURED_COL - The distance in meters from a defined 0th column ",
+                                "enum": [
+                                    "LONGITUDE",
+                                    "LATITUDE",
+                                    "PLANTED_ROW",
+                                    "PLANTED_INDIVIDUAl",
+                                    "GRID_ROW",
+                                    "GRID_COL",
+                                    "MEASURED_ROW",
+                                    "MEASURED_COL"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "replicate": {
+                                "description": "The replicate number of an observation unit. May be the same as blockNumber.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "description": "The ID which uniquely identifies a study within the given database server",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "observationUnitPosition",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putStudiesStudydbidLayoutsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidObservationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidObservationsResponse.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observations": {
+                    "description": "List of observation references which have been created or updated",
+                    "items": {
+                        "properties": {
+                            "observationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationUnitDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "observationVariableDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putStudiesStudydbidObservationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidObservationunitsResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/putStudiesStudydbidObservationunitsResponse.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "observationUnitDbIds": {
+                    "description": "List of observation unit references which have been created or updated",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "newObservationUnitDbIds",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "putStudiesStudydbidObservationunitsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Trials/getTrialsResponse.json
+++ b/src/main/resources/schemas/v1.3/Trials/getTrialsResponse.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "active": {
+                                "description": "Is this trail currently active",
+                                "type": [
+                                    "null",
+                                    "boolean"
+                                ]
+                            },
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "commonCropName": {
+                                "description": "Common name for the crop associated with this trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "documentationURL": {
+                                "description": "A URL to the human readable documentation of this object",
+                                "format": "uri",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "endDate": {
+                                "description": "The date this trial ends",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programDbId": {
+                                "description": "The ID which uniquely identifies a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "programName": {
+                                "description": "The human readable name of a program",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "startDate": {
+                                "description": "The date this trial started",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studies": {
+                                "description": "List of studies inside this trial",
+                                "items": {
+                                    "properties": {
+                                        "locationDbId": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "locationName": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "studyDbId": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "studyName": {
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            },
+                            "trialDbId": {
+                                "description": "The ID which uniquely identifies a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "trialName": {
+                                "description": "The human readable name of a trial",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "trialSummary",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getTrialsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Trials/getTrialsTrialdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Trials/getTrialsTrialdbidResponse.json
@@ -1,0 +1,249 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "active": {
+                    "description": "Is this trail currently active",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
+                },
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Additional arbitrary info",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "commonCropName": {
+                    "description": "Common name for the crop associated with this trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "contacts": {
+                    "description": "List of contact entities associated with this trial",
+                    "items": {
+                        "properties": {
+                            "contactDbId": {
+                                "description": "The ID which uniquely identifies this contact",
+                                "type": "string"
+                            },
+                            "email": {
+                                "description": "The contacts email address ",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "instituteName": {
+                                "description": "The name of the institution which this contact is part of",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "name": {
+                                "description": "The full name of this contact person",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "orcid": {
+                                "description": "The Open Researcher and Contributor ID for this contact person (orcid.org)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "type": {
+                                "description": "The type of person this contact represents (ex: Coordinator, Scientist, PI, etc.)",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "contactDbId"
+                        ],
+                        "title": "contact",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "datasetAuthorship": {
+                    "description": "DEPRECATED in v1.3 - see datasetAuthorships",
+                    "properties": {
+                        "datasetPUI": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "license": {
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "datasetAuthorships": {
+                    "description": "License and citation information for the data in this trial",
+                    "items": {
+                        "properties": {
+                            "datasetPUI": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "license": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "documentationURL": {
+                    "description": "A URL to the human readable documentation of this object",
+                    "format": "uri",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "endDate": {
+                    "description": "The date this trial ends",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "programDbId": {
+                    "description": "A program identifier to search for",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "programName": {
+                    "description": "The human readable name of a program",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "publications": {
+                    "items": {
+                        "properties": {
+                            "publicationPUI": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "publicationReference": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "startDate": {
+                    "description": "The date this trial started",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "studies": {
+                    "description": "List of studies inside this trial",
+                    "items": {
+                        "properties": {
+                            "locationDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "locationName": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyDbId": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "studyName": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "trialDbId": {
+                    "description": "The ID which uniquely identifies a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "trialName": {
+                    "description": "The human readable name of a trial",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "trial",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getTrialsTrialdbidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidPlatesResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidPlatesResponse.json
@@ -1,0 +1,239 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "clientPlateBarcode": {
+                                "description": "(Optional) The value of the bar code attached to this plate",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "clientPlateId": {
+                                "description": "The ID which uniquely identifies this plate to the client making the request",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleSubmissionFormat": {
+                                "description": "Enum for plate formats, usually \"PLATE_96\" for a 96 well plate or \"TUBES\" for plateless format",
+                                "enum": [
+                                    "PLATE_96",
+                                    "TUBES"
+                                ],
+                                "title": "plateFormat",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "samples": {
+                                "items": {
+                                    "properties": {
+                                        "clientSampleBarCode": {
+                                            "description": "(Optional) The value of the bar code attached to this sample",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "clientSampleId": {
+                                            "description": "The ID which uniquely identifies this sample to the client making the request",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "column": {
+                                            "description": "The Column identifier for this samples location in the plate",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "comments": {
+                                            "description": "Generic comments about this sample for the vendor",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "concentration": {
+                                            "description": "A value with units",
+                                            "properties": {
+                                                "units": {
+                                                    "description": "Units (example: \"ng/ul\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "value": {
+                                                    "description": "Value (example: \"2.3\")",
+                                                    "type": [
+                                                        "null",
+                                                        "number"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "measurement",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "organismName": {
+                                            "description": "Scientific organism name",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "row": {
+                                            "description": "The Row identifier for this samples location in the plate",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "speciesName": {
+                                            "description": "Scientific species name",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "taxonomyOntologyReference": {
+                                            "description": "Ontology reference details",
+                                            "properties": {
+                                                "ontologyID": {
+                                                    "description": "Ontology unique ID (example: \"0025034\" or \"4577\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyPrefix": {
+                                                    "description": "Ontology identifier prefix (example: \"PO\" or \"NCBITaxon\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyTerm": {
+                                                    "description": "Ontology term string (example: \"leaf\" or \"Zea mays\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "ontologyReference",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "tissueType": {
+                                            "description": "The type of tissue in this sample. List of accepted tissue types can be found in the Vendor Specs.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "tissueTypeOntologyReference": {
+                                            "description": "Ontology reference details",
+                                            "properties": {
+                                                "ontologyID": {
+                                                    "description": "Ontology unique ID (example: \"0025034\" or \"4577\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyPrefix": {
+                                                    "description": "Ontology identifier prefix (example: \"PO\" or \"NCBITaxon\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyTerm": {
+                                                    "description": "Ontology term string (example: \"leaf\" or \"Zea mays\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "ontologyReference",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "volume": {
+                                            "description": "A value with units",
+                                            "properties": {
+                                                "units": {
+                                                    "description": "Units (example: \"ng/ul\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "value": {
+                                                    "description": "Value (example: \"2.3\")",
+                                                    "type": [
+                                                        "null",
+                                                        "number"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "measurement",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "well": {
+                                            "description": "The Well identifier for this samples location in the plate. Ussually a concatination of Row and Column.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "vendorSample",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "title": "vendorPlate",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorOrdersOrderidPlatesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidResultsResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidResultsResponse.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "properties": {
+                            "additionalInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Additional arbitrary info",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "clientSampleIds": {
+                                "description": "The list of sampleDbIds included in the file",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "fileName": {
+                                "description": "Name of the file",
+                                "type": "string"
+                            },
+                            "fileType": {
+                                "description": "Format of the file",
+                                "type": "string"
+                            },
+                            "fileURL": {
+                                "description": "The URL to a file with the results of a vendor analysis",
+                                "type": "string"
+                            },
+                            "md5sum": {
+                                "description": "MD5 Hash Check Sum for the file to confirm download without error",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "fileURL",
+                            "fileType",
+                            "fileName",
+                            "clientSampleIds"
+                        ],
+                        "title": "vendorResultFile",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorOrdersOrderidResultsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidStatusResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidStatusResponse.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "status": {
+                    "enum": [
+                        "registered",
+                        "received",
+                        "inProgress",
+                        "completed",
+                        "rejected"
+                    ],
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorOrdersOrderidStatusResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersResponse.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "data": {
+                    "items": {
+                        "description": "The details of a vendor order",
+                        "properties": {
+                            "clientId": {
+                                "description": "A unique, alpha-numeric ID which identifies the client to the vendor. Used to connect the order to the correct billing and contact info.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "numberOfSamples": {
+                                "description": "The total number of samples contained in this request. Used for billing and basic validation of the request.",
+                                "type": [
+                                    "null",
+                                    "integer"
+                                ]
+                            },
+                            "orderId": {
+                                "description": "The order id returned by the vendor when the order was successfully submitted.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "requiredServiceInfo": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "A map of additional data required by the requested service. This includes things like Volume and Concentration.",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            },
+                            "serviceId": {
+                                "description": "A unique, alpha-numeric ID which identifies the requested service to be used for this order. The service defines what platform, technology, and markers will be used. A list of service IDs can be retrieved from the Vendor Specs.",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "title": "vendorOrder",
+                        "type": "object"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "data"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorOrdersResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorPlatesSubmissionidResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorPlatesSubmissionidResponse.json
@@ -1,0 +1,254 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Response of a plate submission",
+            "properties": {
+                "clientId": {
+                    "description": "A unique, alpha-numeric ID which identifies the client to the vendor. Used to connect the order to the contract, billing, and contact info.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "numberOfSamples": {
+                    "description": "The total number of samples contained in this request. Used for billing and basic validation of the request.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                },
+                "plates": {
+                    "description": "Array of new plates to be submitted to a vendor",
+                    "items": {
+                        "properties": {
+                            "clientPlateBarcode": {
+                                "description": "(Optional) The value of the bar code attached to this plate",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "clientPlateId": {
+                                "description": "The ID which uniquely identifies this plate to the client making the request",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "sampleSubmissionFormat": {
+                                "description": "Enum for plate formats, usually \"PLATE_96\" for a 96 well plate or \"TUBES\" for plateless format",
+                                "enum": [
+                                    "PLATE_96",
+                                    "TUBES"
+                                ],
+                                "title": "plateFormat",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "samples": {
+                                "items": {
+                                    "properties": {
+                                        "clientSampleBarCode": {
+                                            "description": "(Optional) The value of the bar code attached to this sample",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "clientSampleId": {
+                                            "description": "The ID which uniquely identifies this sample to the client making the request",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "column": {
+                                            "description": "The Column identifier for this samples location in the plate",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "comments": {
+                                            "description": "Generic comments about this sample for the vendor",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "concentration": {
+                                            "description": "A value with units",
+                                            "properties": {
+                                                "units": {
+                                                    "description": "Units (example: \"ng/ul\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "value": {
+                                                    "description": "Value (example: \"2.3\")",
+                                                    "type": [
+                                                        "null",
+                                                        "number"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "measurement",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "organismName": {
+                                            "description": "Scientific organism name",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "row": {
+                                            "description": "The Row identifier for this samples location in the plate",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "speciesName": {
+                                            "description": "Scientific species name",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "taxonomyOntologyReference": {
+                                            "description": "Ontology reference details",
+                                            "properties": {
+                                                "ontologyID": {
+                                                    "description": "Ontology unique ID (example: \"0025034\" or \"4577\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyPrefix": {
+                                                    "description": "Ontology identifier prefix (example: \"PO\" or \"NCBITaxon\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyTerm": {
+                                                    "description": "Ontology term string (example: \"leaf\" or \"Zea mays\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "ontologyReference",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "tissueType": {
+                                            "description": "The type of tissue in this sample. List of accepted tissue types can be found in the Vendor Specs.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "tissueTypeOntologyReference": {
+                                            "description": "Ontology reference details",
+                                            "properties": {
+                                                "ontologyID": {
+                                                    "description": "Ontology unique ID (example: \"0025034\" or \"4577\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyPrefix": {
+                                                    "description": "Ontology identifier prefix (example: \"PO\" or \"NCBITaxon\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "ontologyTerm": {
+                                                    "description": "Ontology term string (example: \"leaf\" or \"Zea mays\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "ontologyReference",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "volume": {
+                                            "description": "A value with units",
+                                            "properties": {
+                                                "units": {
+                                                    "description": "Units (example: \"ng/ul\")",
+                                                    "type": [
+                                                        "null",
+                                                        "string"
+                                                    ]
+                                                },
+                                                "value": {
+                                                    "description": "Value (example: \"2.3\")",
+                                                    "type": [
+                                                        "null",
+                                                        "number"
+                                                    ]
+                                                }
+                                            },
+                                            "title": "measurement",
+                                            "type": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "well": {
+                                            "description": "The Well identifier for this samples location in the plate. Ussually a concatination of Row and Column.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    },
+                                    "title": "vendorSample",
+                                    "type": "object"
+                                },
+                                "type": [
+                                    "null",
+                                    "array"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "vendorPlateGetResponse",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorPlatesSubmissionidResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorSpecificationsResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorSpecificationsResponse.json
@@ -1,0 +1,157 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "properties": {
+                "additionalInfo": {
+                    "additionalProperties": {
+                        "type": "object"
+                    },
+                    "description": "Additional arbitrary information specific to a particular Vendor. Look for the Vedors specific API documentation for more details",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "services": {
+                    "description": "List of platform specifications available at the vendor",
+                    "items": {
+                        "properties": {
+                            "serviceDescription": {
+                                "description": "Description of the vendor platform",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "serviceId": {
+                                "description": "Unique identifier for this service",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "serviceName": {
+                                "description": "The human readable name of a platform",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "servicePlatformMarkerType": {
+                                "description": "The type of markers used in this services platform",
+                                "enum": [
+                                    "FIXED",
+                                    "DISCOVERABLE"
+                                ],
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "servicePlatformName": {
+                                "description": "The technology platform used by this service",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "specificRequirements": {
+                                "description": "Additional arbitrary requirements for a particular platform",
+                                "type": [
+                                    "null",
+                                    "object"
+                                ]
+                            }
+                        },
+                        "title": "vendorSpecificationService",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "vendorContact": {
+                    "properties": {
+                        "vendorAddress": {
+                            "description": "The street address of the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorCity": {
+                            "description": "The name of the city where the vendor is located",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorContactName": {
+                            "description": "The name or identifier of the primary vendor contact",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorCountry": {
+                            "description": "The name of the country where the vendor is located",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorDescription": {
+                            "description": "A description of the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorEmail": {
+                            "description": "The primary email address used to contact the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorName": {
+                            "description": "The human readable name of the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorPhone": {
+                            "description": "The primary phone number used to contact the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "vendorURL": {
+                            "description": "The primary URL for the vendor",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    },
+                    "title": "vendorContact",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                }
+            },
+            "title": "vendorSpecification",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "getVendorSpecificationsResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/postVendorOrdersResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/postVendorOrdersResponse.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Response to an order request",
+            "properties": {
+                "orderId": {
+                    "description": "A unique, alpha-numeric ID which identifies the order .",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "shipmentForms": {
+                    "description": "Array of paper forms which need to be printed and included with the physical shipment",
+                    "items": {
+                        "properties": {
+                            "fileDescription": {
+                                "description": "The human readable long description for this form",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "fileName": {
+                                "description": "The human readable name for this form",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "fileURL": {
+                                "description": "The URL to download this form",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postVendorOrdersResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/Vendor/postVendorPlatesResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/postVendorPlatesResponse.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "result": {
+            "description": "Response to an order request",
+            "properties": {
+                "submissionId": {
+                    "description": "A unique, alpha-numeric ID which identifies a set of plates which have been successfully submitted.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "title": "vendorPlatesSubmissionResponse",
+            "type": "object"
+        }
+    },
+    "required": [
+        "result"
+    ],
+    "title": "postVendorPlatesResponse",
+    "type": "object"
+}

--- a/src/main/resources/schemas/v1.3/metadata.json
+++ b/src/main/resources/schemas/v1.3/metadata.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "metadata": {
+            "properties": {
+                "datafiles": {
+                    "description": "The datafiles key contains a list of file paths, which can be relative or complete URLs. These files contain additional information related to the returned object and can be retrieved by a subsequent call. The empty list should be returned if no additional data files are present.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "pagination": {
+                    "description": "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. Pages are zero indexed, so the first page will be page 0 (zero).",
+                    "properties": {
+                        "currentPage": {
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "pageSize": {
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "totalCount": {
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        },
+                        "totalPages": {
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "status": {
+                    "description": "The status field contains a list of informational status messages from the server. If no status is reported, an empty list should be returned. See Error Reporting for more information.",
+                    "items": {
+                        "properties": {
+                            "code": {
+                                "description": "DEPRECATED in v1.3 - see Error Handling best practice documentation",
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
+                            },
+                            "message": {
+                                "description": "A short message concerning the status of this request/response",
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "description": "The logging level for the attached message",
+                                "enum": [
+                                    "DEBUG",
+                                    "ERROR",
+                                    "WARNING",
+                                    "INFO"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "message",
+                            "messageType"
+                        ],
+                        "title": "status",
+                        "type": "object"
+                    },
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            },
+            "title": "metadata",
+            "type": "object"
+        }
+    },
+    "required": [
+        "metadata"
+    ],
+    "title": "metadata",
+    "type": "object"
+}

--- a/src/main/webapp/advanced/index.html
+++ b/src/main/webapp/advanced/index.html
@@ -125,9 +125,6 @@
                             BrAPI Version
                           </label>
                           <select id="brapiversion" class="form-control" name="brapiversion">
-                            <option>v1.0</option>
-                            <option>v1.1</option>
-                            <option selected>v1.2</option>
                           </select>
                         </div>
                         <div class="form-check">

--- a/src/main/webapp/advanced/js/script.js
+++ b/src/main/webapp/advanced/js/script.js
@@ -172,7 +172,27 @@ $(function() {
     }
 
 
-
+    //Load BrAPI versions
+    function populateBrAPIVersions() {
+        $.ajax({
+            url: 'api/test/brapiversions',
+            type: 'GET',
+            success: function(res) {
+			    var versionElement = document.getElementById('brapiversion');
+				for (var i = 0; i<res.length; i++){
+					var val = res[i];
+				    var opt = document.createElement('option');
+				    opt.value = val;
+				    opt.innerHTML = val;
+				    if(i == res.length - 1){
+				    	opt.selected = true;
+				    }
+				    versionElement.appendChild(opt);
+				}
+            }
+        });
+    }
+    
     // Modal form
     $("#modalForm").submit(function(e){
         e.preventDefault();
@@ -607,8 +627,10 @@ $(function() {
 
         populateServerTable();
 
-        updateCropForm()
+        updateCropForm();
 
+        populateBrAPIVersions();
+        
         // Remove initial /calls option as it is replaced by the one on the tests list.
         $(".del").remove();
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -30,7 +30,13 @@
         <div class="col-xl-10">
           <ul class="nav nav-tabs" id="myTab" role="tablist">
             <li class="nav-item active">
-              <a class="nav-link active" id="testyourown-tab" data-toggle="tab" href="#testyourown" role="tab" aria-controls="testyourown" aria-selected="true">Test your own</a>
+              <a class="nav-link active" id="resources-tab" data-toggle="tab" href="#resources" role="tab" aria-controls="resources" aria-selected="true">BrAPI Resources</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" id="testyourown-tab" data-toggle="tab" href="#testyourown" role="tab" aria-controls="testyourown" aria-selected="false">Test your own</a>
+            </li>
+            <li id="tabSavedReport" class="nav-item" style="display: none">
+              <a class="nav-link" id="report-tab" data-toggle="tab" href="#report" role="tab" aria-controls="report" aria-selected="false">Saved report</a>
             </li>
           </ul>
         </div>
@@ -38,7 +44,66 @@
       <div class="row justify-content-md-center mt-4">
         <div class="col-xl-10">
           <div class="tab-content" id="myTabContent">
-            <div class="tab-pane active" id="testyourown" role="tabpanel" aria-labelledby="testyourown-tab">
+            <div class="tab-pane show active" id="resources" role="tabpanel" aria-labelledby="resources-tab">
+              <div class="row justify-content-md-center">
+                <div class="col-lg-7">
+                  <div class="card bg-light">
+                    <div class="card-header card-default">
+                      <span class="card-title"><i class="fa fa-table"></i> BrAPI Resources <small>taken from the <a href="https://github.com/plantbreeding/API/blob/master/brapi-resources.json">BrAPI repository</a></small></span>
+                    </div>
+                    <table id="resTable" class="table table-hover mb-0" data-sorting="true">
+                      <thead>
+                        <th scope="col" data-sorted="true" class="align-top">
+                          Name
+                        </th>
+                        <th data-breakpoints="all" scope="col" class="align-top">
+                          Description
+                        </th>
+                        <th data-breakpoints="xs sm md" scope="col" class="align-top">
+                          Provider
+                        </th>
+                        <th data-breakpoints="xs" scope="col" class="align-top">
+                          Crop
+                        </th>
+                        <th data-breakpoints="all" scope="col" class="align-top">
+                          Base url
+                        </th>
+                        <th scope="col" class="align-top">
+                          Status<br/>
+                          <small class="text-muted">passed/warning/total</small>
+                        </th>
+                      </thead>
+                      <tbody id="endpoint_table_body">
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div class="col-lg-5">
+                  <div class="card bg-light">
+                    <div class="card-header card-default d-flex justify-content-between">
+                      <div><strong><span class="card-title" id="srTitle"></span></strong></div>
+                      <div class="d-flex">
+                        <select id="time_tab_0" class="form-control">
+                        </select>
+                      </div>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                      <div>
+                        <a class="btn btn-sm btn-link" data-toggle="collapse" href=".skipped_test_0" aria-expanded="false" aria-controls="skipped_test_0">
+                          <span aria-hidden="true">Toggle tests not present in the resource /calls</span>
+                        </a>
+                      </div>
+                      <div class="pr-3">
+                        <small>Median response time: <span id="srTime_0"></span>ms</small>
+                      </div>
+                    </div>
+                    <div class="list-group" id="srList_0">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="tab-pane" id="testyourown" role="tabpanel" aria-labelledby="testyourown-tab">
               <div class="row">
                 <div class="col-xl-7" id="formCol">
                   <div class="card bg-light">
@@ -60,8 +125,6 @@
                             BrAPI Version
                           </label>
                           <select id="brapiversion" class="form-control" name="brapiversion">
-                            <option>v1.0</option>
-                            <option selected>v1.1</option>
                           </select>
                         </div>
                         <div class="form-check">
@@ -80,6 +143,10 @@
                         <div id="statusBar" class="alert alert-danger hidden" role="alert">...</div>
                         <div class="d-flex justify-content-between">
                           <button type="submit" class="btn btn-primary">Test it now! (it may take a few minutes)</button>
+                          <!-- Button trigger modal -->
+                          <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#scheduleModal">
+                            Schedule a periodic test
+                          </button>
                         </div>
                       </form>
                     </div>
@@ -109,6 +176,32 @@
                 </div>
               </div>
             </div>
+            <div class="tab-pane" id="report" role="tabpanel" aria-labelledby="report-tab">
+              <div class="row justify-content-md-center">
+                <div class="col-xl-7">
+                  <div class="card bg-light">
+                    <div class="card-header card-default d-flex justify-content-between">
+                      <div>Test result: <span class="card-title" id="srTitle_2"></span></div>
+                      <div>
+                        <span id="time_tab_2">
+                        </span>
+                      </div>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                      <div>
+                        <a class="btn btn-sm btn-link" data-toggle="collapse" href=".skipped_test_2" aria-expanded="false" aria-controls="skipped_test_2">
+                          <span aria-hidden="true">Toggle tests not present in the resource /calls</span>
+                        </a>
+                      </div>
+                      <div class="pr-3">
+                        <small>Median response time: <span id="srTime_2"></span>ms</small>
+                      </div>
+                    </div>
+                    <div class="list-group" id="srList_2"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -117,12 +210,88 @@
       <div class="container">
         <div class="footer-text">
           <p class="text-muted my-0">&copy; 2018 | IPK-Gatersleben. Site licensed under the MIT License.</p>
-          <p class="text-muted my-0"><small>Last build on ${buildDate} with version ${git.commit.id.abbrev} | Send any issues/requests to the <a target="_blank" href="https://github.com/plantbreeding/IPK-BrAPI-Validator/issues">GitHub Issues Page</a></small></p>
+          <p class="text-muted my-0"><small>Last build on ${buildDate} UTC with version ${git.commit.id.abbrev} | Send any issues/requests to the <a target="_blank" href="https://github.com/plantbreeding/IPK-BrAPI-Validator/issues">GitHub Issues Page</a></small></p>
         </div>
         <a href="http://www.ipk-gatersleben.de"><img src="http://www.ipk-gatersleben.de/fileadmin/template/main/images-ipk/ipklogo.png" class="footer-logo"></a>
         <a href="https://www.leibniz-gemeinschaft.de/en/home/"><img src="http://www.ipk-gatersleben.de/fileadmin/template/main/images-ipk/sign01.png" class="footer-logo"></a>
       </div>
     </footer>
+    <!-- Modal -->
+    <div class="modal fade" id="scheduleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <form id="modalForm">
+            <div class="modal-header">
+              <h5 class="modal-title" id="exampleModalLabel">Set up a periodic report.</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>Register your endpoint here and we'll test it periodically.</p>
+              <p>You'll get an email where you can see at a glance how your BrAPI server development is going.</p>
+              <div class="form-group">
+                <label for="serverUrlModal">
+                  Server URL
+                </label>
+                <input type="url" name="url" id="serverUrlModal" class="form-control font-14" placeholder="https://www.brapiserver.com/brapi/v1/" required>
+                <div class="invalid-feedback">Please provide a valid URL.</div>
+              </div>
+              <div class="form-group">
+                <label for="emailModal">
+                  Email
+                </label>
+                <input type="email" name="email" id="emailModal" class="form-control font-14" aria-describedby="emailHelp" placeholder="dev@brapiserver.com" autocomplete="email" required>
+                <small id="emailHelp">You can stop the test schedule using the unsubscribe link in the test report e-mails</small>
+                <div class="invalid-feedback">Please provide a valid email.</div>
+              </div>
+              <div class="form-check">
+                <label for="daily" class="form-check-label">
+                  <input type="radio" name="frequency" id="daily" value="daily" class="form-check-input">
+                  Daily report
+                </label>
+              </div>
+              <div class="form-check">
+                <label for="weekly" class="form-check-label">
+                  <input type="radio" name="frequency" id="weekly" value="weekly" class="form-check-input" checked>
+                  Weekly report
+                </label>
+              </div>
+              <div class="form-check">
+                <label for="monthly" class="form-check-label">
+                  <input type="radio" name="frequency" id="monthly" value="monthly" class="form-check-input">
+                  Monthly report
+                </label>
+              </div>
+              <div class="form-check mt-3">
+                <strong>Add to resource list</strong>
+                <label for="submitToRepo" class="form-check-label mt-1">
+                  <input type="checkbox" name="submitToRepo" id="submitToRepo" class="form-check-input">
+                  Check this if you want to submit your server to be added to the resource list.
+                </label>
+              </div>
+              <div class="form-group" id="cropSpeciesForm" style="display: none">
+                <label for="cropSpecies">
+                  Crop species
+                </label>
+                <input type="text" name="cropSpecies" id="cropSpecies" class="form-control font-14" placeholder="wheat, barley, multi-crop...">
+                <div class="invalid-feedback">Please provide a valid input.</div>
+              </div>
+              <div class="alert alert-success" role="alert" id="modalSuccess" style="display:none">
+                <i class="fa fa-check" aria-hidden="true"></i> Got it! <span class="modalMessage"></span>
+              </div>
+              <div class="alert alert-danger" role="alert" id="modalFailure" style="display:none">
+                <i class="fa fa-frown-o" aria-hidden="true"></i> Oops! There was something wrong. <span id="modalMessage"></span>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button type="submit" class="btn btn-primary" id="modalSubmit">Submit</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
     <div class="modal fade" id="helpModal" tabindex="-1" role="dialog" aria-hidden="true">
       <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
@@ -155,7 +324,28 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
   <script src="js/spin.min.js"></script>
+  <script src="js/footable.min.js"></script>
   <script src="js/script.js"></script>
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = _paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+    _paq.push(["setCookieDomain", "*.webapps.ipk-gatersleben.de"]);
+    _paq.push(["setDomains", ["*.webapps.ipk-gatersleben.de/brapivalidator","*.webapps.ipk-gatersleben.de/brapivalidator"]]);
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//webstats.ipk-gatersleben.de/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '9']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <noscript><p><img src="//webstats.ipk-gatersleben.de/piwik.php?idsite=9&rec=1" style="border:0;" alt="" /></p></noscript>
+  <!-- End Matomo Code -->
 </body>
 </html>
 <!-- Version: ${git.commit.id.abbrev} -->

--- a/src/main/webapp/js/script.js
+++ b/src/main/webapp/js/script.js
@@ -172,7 +172,27 @@ $(function() {
     }
 
 
-
+    //Load BrAPI versions
+    function populateBrAPIVersions() {
+        $.ajax({
+            url: 'api/test/brapiversions',
+            type: 'GET',
+            success: function(res) {
+			    var versionElement = document.getElementById('brapiversion');
+				for (var i = 0; i<res.length; i++){
+					var val = res[i];
+				    var opt = document.createElement('option');
+				    opt.value = val;
+				    opt.innerHTML = val;
+				    if(i == res.length - 1){
+				    	opt.selected = true;
+				    }
+				    versionElement.appendChild(opt);
+				}
+            }
+        });
+    }
+    
     // Modal form
     $("#modalForm").submit(function(e){
         e.preventDefault();
@@ -603,6 +623,14 @@ $(function() {
     // Initializes variables, forms, listeners...
     function main () {
 
+        showReportIfInParams();
+
+        populateServerTable();
+
+        updateCropForm();
+
+        populateBrAPIVersions();
+        
         // Remove initial /calls option as it is replaced by the one on the tests list.
         $(".del").remove();
 
@@ -611,6 +639,31 @@ $(function() {
 
 
         updateFullUrl();
+        $("body").on('click', '.statusbtn', function() {
+            currentResource = $(this).data('id');
+            $("#resTable > tbody > tr").removeClass("table-active");
+            $("#row-" + currentResource).addClass("table-active");
+            customReport.name = resourcesData[$(this).data('id')].name;
+            var d = new Date(resourcesData[$(this).data('id')].date);
+            customReport.date = d.toLocaleDateString();
+            showTimeDropdown();
+            showShortReport($(this).data('id'), 0);
+        });
+        $("#time_tab_0").change(function(){
+            var value = $(this).val();
+            showShortReport(currentResource, value);
+        });
+
+        $("#pdfTest_0").click(function() {
+            var d = new Date(resourcesData[currentResource].lastTestReports[0].date);
+            printPDF(resourcesData[currentResource].name, d.toLocaleDateString(), 0);
+        });
+        $("#pdfTest_1").click(function() {
+            printPDF(customReport.name, customReport.date, 1);
+        });
+        $("#pdfTest_2").click(function() {
+            printPDF(linkedReport.name, linkedReport.date, 2);
+        });
 
     }
     main();


### PR DESCRIPTION
@martinbaste @langeipk @patrick-koenig 
Not sure who should review/deploy this. Do I need to add Mehmood?

- I added Collection and Schemas for BrAPI v1.3. They are not perfectly detailed, but they are pretty good and generated directly from the swagger doc. If details are missing (required fields, array lengths, etc), they should be added to the swagger doc

- I attempted to solve #30 by adding a flag indicating the origin of the test and relaxes the need for port 80 if someone is using the "Test your own" tab. There is probably a cleaner way to do this with a "TestContext" object of some kind, but I was lazy for right now.

- Github had a notification that the Jetty packages were outdated, so I updated to the recommended version. Running on my laptop, it seems like everything still works as before after a Maven clean install.

- I added an endpoint for the BrAPI versions list so that the web page and the backend are working from the same list.

Let me know if you have questions 