### PR TITLE
update the word Reference to be spelled correctly

### DIFF
--- a/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesResponse.json
+++ b/src/main/resources/schemas/v1.3/GermplasmAttributes/getAttributesResponse.json
@@ -126,7 +126,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -180,7 +180,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -200,7 +200,7 @@
                                     "object"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -254,7 +254,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"
@@ -287,7 +287,7 @@
                                             "integer"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -341,7 +341,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -488,7 +488,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -542,7 +542,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"

--- a/src/main/resources/schemas/v1.3/Images/getImagesImagedbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getImagesImagedbidResponse.json
@@ -65,7 +65,7 @@
                     ]
                 },
                 "imageLocation": {
-                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                     "properties": {
                         "geometry": {
                             "oneOf": [

--- a/src/main/resources/schemas/v1.3/Images/getImagesResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getImagesResponse.json
@@ -69,7 +69,7 @@
                                 ]
                             },
                             "imageLocation": {
-                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                                 "properties": {
                                     "geometry": {
                                         "oneOf": [

--- a/src/main/resources/schemas/v1.3/Images/getSearchImagesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/getSearchImagesSearchresultsdbidResponse.json
@@ -69,7 +69,7 @@
                                 ]
                             },
                             "imageLocation": {
-                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                                "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                                 "properties": {
                                     "geometry": {
                                         "oneOf": [

--- a/src/main/resources/schemas/v1.3/Images/postImagesResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/postImagesResponse.json
@@ -65,7 +65,7 @@
                     ]
                 },
                 "imageLocation": {
-                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                     "properties": {
                         "geometry": {
                             "oneOf": [

--- a/src/main/resources/schemas/v1.3/Images/putImagesImagedbidImagecontentResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/putImagesImagedbidImagecontentResponse.json
@@ -65,7 +65,7 @@
                     ]
                 },
                 "imageLocation": {
-                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                     "properties": {
                         "geometry": {
                             "oneOf": [

--- a/src/main/resources/schemas/v1.3/Images/putImagesImagedbidResponse.json
+++ b/src/main/resources/schemas/v1.3/Images/putImagesImagedbidResponse.json
@@ -65,7 +65,7 @@
                     ]
                 },
                 "imageLocation": {
-                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate refernce system.",
+                    "description": "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.",
                     "properties": {
                         "geometry": {
                             "oneOf": [

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsMethoddbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsMethoddbidResponse.json
@@ -40,7 +40,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -94,7 +94,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getMethodsResponse.json
@@ -43,7 +43,7 @@
                                     "string"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -97,7 +97,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getScalesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getScalesResponse.json
@@ -31,7 +31,7 @@
                                     "integer"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -85,7 +85,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getScalesScaledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getScalesScaledbidResponse.json
@@ -28,7 +28,7 @@
                         "integer"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -82,7 +82,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getSearchVariablesSearchresultsdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getSearchVariablesSearchresultsdbidResponse.json
@@ -98,7 +98,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -152,7 +152,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -186,7 +186,7 @@
                                     "string"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -240,7 +240,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"
@@ -273,7 +273,7 @@
                                             "integer"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -327,7 +327,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -474,7 +474,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -528,7 +528,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesObservationvariabledbidResponse.json
@@ -95,7 +95,7 @@
                                 "string"
                             ]
                         },
-                        "ontologyRefernce": {
+                        "ontologyReference": {
                             "properties": {
                                 "documentationLinks": {
                                     "description": "links to various ontology documentation",
@@ -149,7 +149,7 @@
                             "required": [
                                 "ontologyName"
                             ],
-                            "title": "ontologyRefernce",
+                            "title": "ontologyReference",
                             "type": [
                                 "null",
                                 "object"
@@ -183,7 +183,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -237,7 +237,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"
@@ -270,7 +270,7 @@
                                 "integer"
                             ]
                         },
-                        "ontologyRefernce": {
+                        "ontologyReference": {
                             "properties": {
                                 "documentationLinks": {
                                     "description": "links to various ontology documentation",
@@ -324,7 +324,7 @@
                             "required": [
                                 "ontologyName"
                             ],
-                            "title": "ontologyRefernce",
+                            "title": "ontologyReference",
                             "type": [
                                 "null",
                                 "object"
@@ -471,7 +471,7 @@
                                 "string"
                             ]
                         },
-                        "ontologyRefernce": {
+                        "ontologyReference": {
                             "properties": {
                                 "documentationLinks": {
                                     "description": "links to various ontology documentation",
@@ -525,7 +525,7 @@
                             "required": [
                                 "ontologyName"
                             ],
-                            "title": "ontologyRefernce",
+                            "title": "ontologyReference",
                             "type": [
                                 "null",
                                 "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/getVariablesResponse.json
@@ -98,7 +98,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -152,7 +152,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -186,7 +186,7 @@
                                     "string"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -240,7 +240,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"
@@ -273,7 +273,7 @@
                                             "integer"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -327,7 +327,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -474,7 +474,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -528,7 +528,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postMethodsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postMethodsResponse.json
@@ -40,7 +40,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -94,7 +94,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postScalesResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postScalesResponse.json
@@ -28,7 +28,7 @@
                         "integer"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -82,7 +82,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/postTraitsResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/postTraitsResponse.json
@@ -49,7 +49,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -103,7 +103,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putMethodsMethoddbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putMethodsMethoddbidResponse.json
@@ -40,7 +40,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -94,7 +94,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putScalesScaledbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putScalesScaledbidResponse.json
@@ -28,7 +28,7 @@
                         "integer"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -82,7 +82,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/ObservationVariables/putTraitsTraitdbidResponse.json
+++ b/src/main/resources/schemas/v1.3/ObservationVariables/putTraitsTraitdbidResponse.json
@@ -49,7 +49,7 @@
                         "string"
                     ]
                 },
-                "ontologyRefernce": {
+                "ontologyReference": {
                     "properties": {
                         "documentationLinks": {
                             "description": "links to various ontology documentation",
@@ -103,7 +103,7 @@
                     "required": [
                         "ontologyName"
                     ],
-                    "title": "ontologyRefernce",
+                    "title": "ontologyReference",
                     "type": [
                         "null",
                         "object"

--- a/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationvariablesResponse.json
+++ b/src/main/resources/schemas/v1.3/Studies/getStudiesStudydbidObservationvariablesResponse.json
@@ -98,7 +98,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -152,7 +152,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -186,7 +186,7 @@
                                     "string"
                                 ]
                             },
-                            "ontologyRefernce": {
+                            "ontologyReference": {
                                 "properties": {
                                     "documentationLinks": {
                                         "description": "links to various ontology documentation",
@@ -240,7 +240,7 @@
                                 "required": [
                                     "ontologyName"
                                 ],
-                                "title": "ontologyRefernce",
+                                "title": "ontologyReference",
                                 "type": [
                                     "null",
                                     "object"
@@ -273,7 +273,7 @@
                                             "integer"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -327,7 +327,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"
@@ -474,7 +474,7 @@
                                             "string"
                                         ]
                                     },
-                                    "ontologyRefernce": {
+                                    "ontologyReference": {
                                         "properties": {
                                             "documentationLinks": {
                                                 "description": "links to various ontology documentation",
@@ -528,7 +528,7 @@
                                         "required": [
                                             "ontologyName"
                                         ],
-                                        "title": "ontologyRefernce",
+                                        "title": "ontologyReference",
                                         "type": [
                                             "null",
                                             "object"

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidPlatesResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorOrdersOrderidPlatesResponse.json
@@ -133,7 +133,7 @@
                                                     ]
                                                 }
                                             },
-                                            "title": "ontologyReference",
+                                            "title": "vendorOntologyReference",
                                             "type": [
                                                 "null",
                                                 "object"
@@ -171,7 +171,7 @@
                                                     ]
                                                 }
                                             },
-                                            "title": "ontologyReference",
+                                            "title": "vendorOntologyReference",
                                             "type": [
                                                 "null",
                                                 "object"

--- a/src/main/resources/schemas/v1.3/Vendor/getVendorPlatesSubmissionidResponse.json
+++ b/src/main/resources/schemas/v1.3/Vendor/getVendorPlatesSubmissionidResponse.json
@@ -149,7 +149,7 @@
                                                     ]
                                                 }
                                             },
-                                            "title": "ontologyReference",
+                                            "title": "vendorOntologyReference",
                                             "type": [
                                                 "null",
                                                 "object"
@@ -187,7 +187,7 @@
                                                     ]
                                                 }
                                             },
-                                            "title": "ontologyReference",
+                                            "title": "vendorOntologyReference",
                                             "type": [
                                                 "null",
                                                 "object"


### PR DESCRIPTION
@patrick-koenig 
If you saw my community update email, you know that I accidentally misspelled "Reference" and then copied the misspelling everywhere. This branch updates the spelling in all the JSON schema files.