### PR TITLE
Use OAuth2 access token if provided

### DIFF
--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/apiresources/SingleTestResource.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/apiresources/SingleTestResource.java
@@ -2,8 +2,6 @@ package de.ipk_gatersleben.bit.bi.bridge.brapicomp.apiresources;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,6 +13,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.process.internal.RequestScoped;
@@ -25,7 +24,6 @@ import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.TestReport;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.TestCollection;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteReport;
-import de.ipk_gatersleben.bit.bi.bridge.brapicomp.utils.ApiResourceService;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.utils.JsonMessageManager;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.utils.RunnerService;
 
@@ -49,7 +47,8 @@ public class SingleTestResource {
     @Path("/call")
     @Produces(MediaType.APPLICATION_JSON)
     public Response callTest(@QueryParam("url") String url, 
-    		@QueryParam("brapiversion") @DefaultValue("") String version,
+            @QueryParam("accessToken") @DefaultValue("") String accessToken,
+            @QueryParam("brapiversion") @DefaultValue("") String version,
     		@QueryParam("strict") @DefaultValue("") String strict) {
 
         LOGGER.debug("New GET /call call.");
@@ -74,7 +73,7 @@ public class SingleTestResource {
             InputStream inJson = TestCollection.class.getResourceAsStream(collectionResource);
             TestCollection tc = mapper.readValue(inJson, TestCollection.class);
             
-            Resource res = new Resource(url);
+            Resource res = new Resource(url, accessToken);
             TestSuiteReport testSuiteReport = RunnerService.testEndpointWithCall(res, tc, allowAdditional, singleTest);
             TestReport report = new TestReport(res, mapper.writeValueAsString(testSuiteReport));
             

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/dbentities/Resource.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/dbentities/Resource.java
@@ -54,6 +54,9 @@ public class Resource implements Comparable<Resource> {
 	@JsonProperty("base-url")
 	@DatabaseField(canBeNull = false, columnName = URL_FIELD_NAME)
 	private String url;
+	
+    @JsonProperty("access-token")
+	private String accessToken;
 
 	@DatabaseField(columnName = CROP_FIELD_NAME)
 	private String crop;
@@ -101,11 +104,15 @@ public class Resource implements Comparable<Resource> {
 	public Resource() {
 	}
 
-	public Resource(String url) throws MalformedURLException {
-		this.setUrl(url);
-	}
+    public Resource(String url) throws MalformedURLException {
+        this.setUrl(url);
+    }
+    public Resource(String url, String accessToken) throws MalformedURLException {
+        this.setUrl(url);
+        this.setAccessToken(accessToken);
+    }
 
-	public Resource(String u, String e, String f) throws IllegalArgumentException, MalformedURLException {
+    public Resource(String u, String e, String f) throws IllegalArgumentException, MalformedURLException {
 		this.setUrl(u);
 		this.setEmail(e);
 		this.setFrequency(f);
@@ -129,6 +136,22 @@ public class Resource implements Comparable<Resource> {
 	public String getUrl() {
 		return url;
 	}
+	
+	/**
+     * Sets the access token to access OAuth2 protected BrAPI endpoint
+     *
+     * @param accessToken the new access token
+     */
+	public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+	
+	/**
+     * @return the access token
+     */
+	public String getAccessToken() {
+        return accessToken;
+    }
 
 	/**
 	 * @param e

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/reports/TestSuiteReport.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/reports/TestSuiteReport.java
@@ -3,6 +3,8 @@ package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
+
 /**
  * Contains multiple TestCollectionReports and the base url to be used (endpoint url) in those collections.
  */
@@ -10,11 +12,11 @@ public class TestSuiteReport {
 
 	private List<TestCollectionReport> testCollections = new ArrayList<TestCollectionReport>();
     private String id;
-    private String baseUrl;
+    private Resource ep;
 
-    public TestSuiteReport(String id, String url) {
+    public TestSuiteReport(String id, Resource ep) {
         setId(id);
-        setBaseUrl(url);
+        setEp(ep);
     }
 
     public String getId() {
@@ -26,12 +28,12 @@ public class TestSuiteReport {
     }
 
     public String getBaseUrl() {
-        return baseUrl;
+        return ep.getUrl();
     }
 
 
-    public void setBaseUrl(String url) {
-        baseUrl = url;
+    public void setEp(Resource ep) {
+        this.ep = ep;
     }
 
     public void addTestCollectionReport(TestCollectionReport tc) {

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CallTestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CallTestSuiteRunner.java
@@ -1,6 +1,7 @@
 package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.runner;
 
 
+import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.TestCollection;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestCollectionReport;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteReport;
@@ -12,19 +13,19 @@ import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteRepor
 public class CallTestSuiteRunner implements TestSuiteRunner {
 
     private String id;
-    private String url;
+    private Resource ep;
     private TestCollection testCollection;
 
     /**
      * Constructor
      *
      * @param string Some id to set for this test run
-     * @param url    Base URL of the endpoint to be tested
+     * @param ep    Base URL of the endpoint to be tested
      * @param tc 
      */
-    public CallTestSuiteRunner(String string, String url, TestCollection tc) {
+    public CallTestSuiteRunner(String string, Resource ep, TestCollection tc) {
         this.setId(string);
-        this.setUrl(url);
+        this.setEp(ep);
         this.setTestCollection(tc);
     }
 
@@ -35,8 +36,8 @@ public class CallTestSuiteRunner implements TestSuiteRunner {
      * @return Test report
      */
     public TestSuiteReport runTests(boolean allowAdditional, Boolean singleTest) {
-        TestSuiteReport testSuiteReport = new TestSuiteReport(id, url);
-        TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, url);
+        TestSuiteReport testSuiteReport = new TestSuiteReport(id, ep);
+        TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, ep);
         TestCollectionReport tcr = testCollectionRunner.runTestsFromCall(allowAdditional, singleTest);
         testSuiteReport.addTestCollectionReport(tcr);
         return testSuiteReport;
@@ -55,19 +56,20 @@ public class CallTestSuiteRunner implements TestSuiteRunner {
     public void setId(String id) {
         this.id = id;
     }
+    
+    public Resource getEp() {
+        return ep;
+    }
+    
+    public void setEp(Resource ep) {
+        this.ep = ep;
+    }
 
     /**
      * @return the url
      */
     public String getUrl() {
-        return url;
-    }
-
-    /**
-     * @param url the url to set
-     */
-    public void setUrl(String url) {
-        this.url = url;
+        return ep.getUrl();
     }
 
     public void setTestCollection(TestCollection tc) {

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CustomTestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/CustomTestSuiteRunner.java
@@ -1,6 +1,7 @@
 package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.runner;
 
 
+import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.TestCollection;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestCollectionReport;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteReport;
@@ -12,7 +13,7 @@ import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteRepor
 public class CustomTestSuiteRunner implements TestSuiteRunner {
 
     private String id;
-    private String url;
+    private Resource ep;
     private TestCollection testCollection;
 
     /**
@@ -22,9 +23,9 @@ public class CustomTestSuiteRunner implements TestSuiteRunner {
      * @param url    Base URL of the endpoint to be tested
      * @param tc     TestCollection config instance.
      */
-    public CustomTestSuiteRunner(String string, String url, TestCollection tc) {
+    public CustomTestSuiteRunner(String string, Resource ep, TestCollection tc) {
         this.setId(string);
-        this.setUrl(url);
+        this.setEp(ep);
         this.setTestCollection(tc);
     }
 
@@ -34,8 +35,8 @@ public class CustomTestSuiteRunner implements TestSuiteRunner {
      * @return Test report
      */
     public TestSuiteReport runTests(boolean allowAdditional, Boolean singleTest) {
-        TestSuiteReport testSuiteReport = new TestSuiteReport(id, url);
-        TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, url);
+        TestSuiteReport testSuiteReport = new TestSuiteReport(id, ep);
+        TestCollectionRunner testCollectionRunner = new TestCollectionRunner(testCollection, ep);
         TestCollectionReport tcr = testCollectionRunner.runTests(allowAdditional);
         testSuiteReport.addTestCollectionReport(tcr);
         return testSuiteReport;
@@ -54,20 +55,23 @@ public class CustomTestSuiteRunner implements TestSuiteRunner {
     public void setId(String id) {
         this.id = id;
     }
+    
+    public Resource getEp() {
+        return ep;
+    }
+    
+    @Override
+    public void setEp(Resource ep) {
+        this.ep = ep;
+    }
 
     /**
      * @return the url
      */
     public String getUrl() {
-        return url;
+        return ep.getUrl();
     }
 
-    /**
-     * @param url the url to set
-     */
-    public void setUrl(String url) {
-        this.url = url;
-    }
 
     public void setTestCollection(TestCollection tc) {
         this.testCollection = tc;

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestCollectionRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestCollectionRunner.java
@@ -3,6 +3,7 @@ package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.runner;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.Folder;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.TestCollection;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestCollectionReport;
@@ -13,7 +14,7 @@ import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.VariableStorag
  * Runs the tests for a test collection
  */
 public class TestCollectionRunner {
-    private String url;
+    private Resource ep;
     private TestCollection testCollection;
     //private VariableStorage variableStorage;
 
@@ -21,11 +22,11 @@ public class TestCollectionRunner {
      * Constructor
      *
      * @param tc  TestCollection config instance
-     * @param url Base URL of the endpoint to be tested.
+     * @param ep Base URL of the endpoint to be tested.
      */
-    public TestCollectionRunner(TestCollection tc, String url) {
+    public TestCollectionRunner(TestCollection tc, Resource ep) {
         this.testCollection = tc;
-        this.url = url;
+        this.ep = ep;
     }
 
     /**
@@ -35,13 +36,14 @@ public class TestCollectionRunner {
      */
     public TestCollectionReport runTests(boolean allowAdditional) {
         String name = testCollection.getInfo().getName();
-        TestCollectionReport tcr = new TestCollectionReport(name, url);
-        String baseUrl = url.replaceAll("/$", "");
+        TestCollectionReport tcr = new TestCollectionReport(name, ep.getUrl());
+        String baseUrl = ep.getUrl().replaceAll("/$", "");
+        String accessToken = ep.getAccessToken();
         VariableStorage storage = new VariableStorage(baseUrl);
         List<Folder> folderList = testCollection.getItem();
         folderList.forEach(folder -> {
             TestFolderRunner tfr = new TestFolderRunner(baseUrl, folder, storage);
-            TestFolderReport tfReport = tfr.runTests(allowAdditional);
+            TestFolderReport tfReport = tfr.runTests(accessToken, allowAdditional);
             tcr.addFolder(tfReport);
         });
         tcr.setVariables(storage);
@@ -50,8 +52,9 @@ public class TestCollectionRunner {
 
 	public TestCollectionReport runTestsFromCall(boolean allowAdditional, Boolean singleTest) {
         String name = testCollection.getInfo().getName();
-        TestCollectionReport tcr = new TestCollectionReport(name, url);
-        String baseUrl = url.replaceAll("/$", "");
+        TestCollectionReport tcr = new TestCollectionReport(name, ep.getUrl());
+        String baseUrl = ep.getUrl().replaceAll("/$", "");
+        String accessToken = ep.getAccessToken();
         VariableStorage storage = new VariableStorage(baseUrl);
         
         List<Folder> folderList = testCollection.getItem();
@@ -62,9 +65,9 @@ public class TestCollectionRunner {
             TestFolderRunner tfr = new TestFolderRunner(baseUrl, folderList.get(i), storage);
             TestFolderReport tfReport;
             if (i == 0) {
-            	tfReport = tfr.runTests(doneTests, allowAdditional, singleTest);
+            	tfReport = tfr.runTests(doneTests, accessToken, allowAdditional, singleTest);
             } else {
-            	tfReport = tfr.runTestsFromCall(doneTests, allowAdditional, singleTest);
+            	tfReport = tfr.runTestsFromCall(doneTests, accessToken, allowAdditional, singleTest);
             }
            
             tcr.addFolder(tfReport);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestFolderRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestFolderRunner.java
@@ -36,10 +36,11 @@ public class TestFolderRunner {
     /**
      * Runs the tests specified in the Folder config
      * @param doneTests 
+     * @param accessToken 
      *
      * @return Test report.
      */
-    public TestFolderReport runTests(List<String> doneTests, boolean allowAdditional, Boolean singleTest) {
+    public TestFolderReport runTests(List<String> doneTests, String accessToken, boolean allowAdditional, Boolean singleTest) {
         TestFolderReport tcr = new TestFolderReport(this.baseUrl);
         tcr.setName(this.folder.getName());
         tcr.setDescription(this.folder.getDescription());
@@ -47,7 +48,7 @@ public class TestFolderRunner {
         LinkedHashMap<String, Object> folderTests = new LinkedHashMap<String, Object>();
         itemList.forEach(item -> {
             TestItemRunner tir = new TestItemRunner(item, storage);
-            TestItemReport tiReport = tir.runTests(allowAdditional, singleTest);
+            TestItemReport tiReport = tir.runTests(accessToken, allowAdditional, singleTest);
             tcr.addTestReport(tiReport);
             doneTests.add(item.getName());
             folderTests.put(item.getName(), tiReport);
@@ -58,15 +59,16 @@ public class TestFolderRunner {
     
     /**
      * Runs the tests specified in the Folder config
+     * @param accessToken
      * @param doneTests 
      *
      * @return Test report.
      */
-    public TestFolderReport runTests(boolean allowAdditional) {
-    	return runTests(new ArrayList<String>(), allowAdditional, false);
+    public TestFolderReport runTests(String accessToken, boolean allowAdditional) {
+    	return runTests(new ArrayList<String>(), accessToken, allowAdditional, false);
     }
 
-	public TestFolderReport runTestsFromCall(List<String> doneTests, boolean allowAdditional, Boolean singleTest) {
+	public TestFolderReport runTestsFromCall(List<String> doneTests, String accessToken, boolean allowAdditional, Boolean singleTest) {
         TestFolderReport tcr = new TestFolderReport(this.baseUrl);
         tcr.setName(this.folder.getName());
         tcr.setDescription(this.folder.getDescription());        
@@ -90,7 +92,7 @@ public class TestFolderRunner {
         		    		
         		if (storage.getKeys().containsAll(item.getRequires())) {
         			TestItemRunner tir = new TestItemRunner(item, storage);
-            		TestItemReport tiReport = tir.runTests(allowAdditional, singleTest);
+            		TestItemReport tiReport = tir.runTests(accessToken, allowAdditional, singleTest);
                     tcr.addTestReport(tiReport);
                     doneTests.add(item.getName());
                     folderTests.put(item.getName(), tiReport);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestItemRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestItemRunner.java
@@ -3,15 +3,12 @@ package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.runner;
 import static io.restassured.RestAssured.given;
 
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import javax.net.ssl.SSLHandshakeException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ConnectionClosedException;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -31,9 +28,9 @@ import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestExecReport
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestItemReport;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.VariableStorage;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.utils.RunnerService;
+import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
-import io.restassured.RestAssured;
 /**
  * Run tests for an item element.
  */
@@ -71,13 +68,14 @@ public class TestItemRunner {
 
     /**
      * Run the tests
+     * @param accessToken 
      * @param singleTest 
      *
      * @return Report
      */
-    public TestItemReport runTests(boolean allowAdditional, Boolean singleTest) {
+    public TestItemReport runTests(String accessToken, boolean allowAdditional, Boolean singleTest) {
     	
-        this.vr = connect(singleTest);
+        this.vr = connect(accessToken, singleTest);
         
         //TODO: Only first event in Item.event is executed.
         List<String> execList = this.item.getEvent().get(0).getExec();
@@ -219,7 +217,7 @@ public class TestItemRunner {
      *
      * @return server response
      */
-    private ValidatableResponse connect(Boolean singleTest) {
+    private ValidatableResponse connect(String accessToken, Boolean singleTest) {
         LOGGER.info("New Request. URL: " + this.url);
         
         RestAssured.useRelaxedHTTPSValidation();
@@ -233,6 +231,10 @@ public class TestItemRunner {
         	}
             RequestSpecification rs = given()
             		.contentType("application/json");
+            
+            if (StringUtils.isNotBlank(accessToken)) {
+                rs.given().header("Authorization", "Bearer " + accessToken);
+            }
 			List<Param> params = this.item.getParameters();
 			if (this.method.equals("GET")) {
 				if (params != null) {
@@ -296,7 +298,7 @@ public class TestItemRunner {
         try {
             vr.statusCode(i);
         } catch (AssertionError e1) {
-            LOGGER.info("Wrong Status code");
+            LOGGER.info("Wrong Status code " + statusCode);
             LOGGER.info("== cause ==");
             LOGGER.info(e1.getMessage());
             tr.addMessage("Response Status code: " + statusCode);

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestSuiteRunner.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/testing/runner/TestSuiteRunner.java
@@ -1,5 +1,6 @@
 package de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.runner;
 
+import de.ipk_gatersleben.bit.bi.bridge.brapicomp.dbentities.Resource;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.config.TestCollection;
 import de.ipk_gatersleben.bit.bi.bridge.brapicomp.testing.reports.TestSuiteReport;
 
@@ -29,7 +30,7 @@ public interface TestSuiteRunner {
     /**
      * @param url the url to set
      */
-    public void setUrl(String url);
+    public void setEp(Resource ep);
 
     void setTestCollection(TestCollection tc);
 

--- a/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/utils/RunnerService.java
+++ b/src/main/java/de/ipk_gatersleben/bit/bi/bridge/brapicomp/utils/RunnerService.java
@@ -37,7 +37,7 @@ public class RunnerService {
         if (ep.getId() != null) {
             id = ep.getId().toString();
         }
-        CustomTestSuiteRunner t = new CustomTestSuiteRunner(id, ep.getUrl(), testCollection);
+        CustomTestSuiteRunner t = new CustomTestSuiteRunner(id, ep, testCollection);
         return t.runTests(allowAdditional, false);
     }
     
@@ -54,7 +54,7 @@ public class RunnerService {
         if (ep.getId() != null) {
             id = ep.getId().toString();
         }
-        CallTestSuiteRunner t = new CallTestSuiteRunner(id, ep.getUrl(), tc);
+        CallTestSuiteRunner t = new CallTestSuiteRunner(id, ep, tc);
         return t.runTests(allowAdditional, singleTest);
     }
 
@@ -134,7 +134,7 @@ public class RunnerService {
      */
     public static TestItemReport singleTestEndpoint(Item simple, boolean allowAdditional) {
         TestItemRunner tir = new TestItemRunner(simple);
-        return tir.runTests(allowAdditional, false);
+        return tir.runTests(null, allowAdditional, false);
     }
 
     /**
@@ -146,7 +146,7 @@ public class RunnerService {
      */
     public static TestItemReport singleTestEndpoint(Item simple, VariableStorage storage, boolean allowAdditional) {
         TestItemRunner tir = new TestItemRunner(simple, storage);
-        return tir.runTests(allowAdditional, false);
+        return tir.runTests(null, allowAdditional, false);
     }
 
 	public static void TestAllPublicEndpoints(TestCollection tc, boolean allowAdditional) throws SQLException {

--- a/src/main/webapp/advanced/index.html
+++ b/src/main/webapp/advanced/index.html
@@ -127,6 +127,13 @@
                           <select id="brapiversion" class="form-control" name="brapiversion">
                           </select>
                         </div>
+                        <div class="form-group">
+                          <label for="accessToken">
+                            OAuth2 Access token for OAuth2 protected BrAPI (<code>Authorization: Bearer &lt;TOKEN&gt;</code>)
+                          </label>
+                          <input type="text" id="accessToken" class="form-control" name="accessToken" />
+                          <small id="serverHelp">Enter a valid OAuth2 access token that should be used by BRAVA to make requests to your BrAPI server.</small>
+                        </div>
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" id="strict" name="strict">
                           <label class="form-check-label" for="strict">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -127,6 +127,13 @@
                           <select id="brapiversion" class="form-control" name="brapiversion">
                           </select>
                         </div>
+                        <div class="form-group">
+                          <label for="accessToken">
+                            OAuth2 Access token for OAuth2 protected BrAPI (<code>Authorization: Bearer &lt;TOKEN&gt;</code>)
+                          </label>
+                          <input type="text" id="accessToken" class="form-control" name="accessToken" />
+                          <small id="serverHelp">Enter a valid OAuth2 access token that should be used by BRAVA to make requests to your BrAPI server.</small>
+                        </div>
                         <div class="form-check">
                           <input class="form-check-input" type="checkbox" id="strict" name="strict">
                           <label class="form-check-label" for="strict">


### PR DESCRIPTION
- Updated UI
- Updated test runners

Addresses #2. Does not handle persisting of auth data for scheduled runs.