### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# ----------------------------------------------------------------------
+# BUILD BRAPI VALIDATOR WAR FILE
+# ----------------------------------------------------------------------
+FROM maven as build
+
+WORKDIR /src
+COPY . .
+RUN touch /src/src/main/resources/config.properties
+RUN mvn clean install
+
+# ----------------------------------------------------------------------
+# BUILD ACTUAL TOMCAT SERVER WITH ONLY BRAVA
+# ----------------------------------------------------------------------
+FROM tomcat:alpine
+
+RUN rm -rf /usr/local/tomcat/webapps && mkdir -p /usr/local/tomcat/webapps
+
+COPY --from=build /src/target/BrAPI-validator /usr/local/tomcat/webapps/ROOT/

--- a/README.md
+++ b/README.md
@@ -151,3 +151,10 @@ The complex tests (Test Collections) are stored in the collections/ folder. They
 ## Adding tests
 
 * Edit test collection found in /collections/
+
+## Docker
+
+You can use the Dockerfile to create a docker version of the BRAVA application, which will be installed in the tomcat server. The tomcat server will only have the BRAVA application. To use this with your own BRAPI application you can start the docker image, and use the local test to point it to your machine. You can use `host.docker.internal` in the URL, localhost  will resolve to the BRAVA servercontainer and can thus not be used.
+
+To build you can use `docker build -t brava .` and you can run it using `docker run -d --rm -p 8080:8080 brava`. You can now access the BRAVA application at http://localhost:8080/ and use for example http://host.docker.internal:5000/brapi/v1 as the url that needs to be tested.
+


### PR DESCRIPTION
This adds a Dockerfile to create a docker image that can be used on your local machine when creating a brapi implementation. For example we start the docker image `docker run -d --rm -p 8080:8080 brava` followed by starting the brapi server on the local machine.

Now we can check the validity of the brapi implementation using the Test your own tab and using (in our case) http://host.docker.internal:5000/brapi/v1 as the URL.