### PR TITLE
Fix schema pathing issues with more Java-resource based approach

### DIFF
--- a/brava-app/core/src/main/java/org/brapi/brava/core/validation/ItemValidator.java
+++ b/brava-app/core/src/main/java/org/brapi/brava/core/validation/ItemValidator.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ConnectionClosedException;
+import org.brapi.brava.core.exceptions.CollectionNotFound;
 import org.brapi.brava.core.model.Item;
 import org.brapi.brava.core.model.Param;
 import org.brapi.brava.core.reports.ExecReport;
@@ -378,9 +379,9 @@ public class ItemValidator {
         execReport.setSchema(schemaPath);
         try {
         	String jsonString = validatableResponse.extract().response().asString();
-            SchemaValidator schemaValidator = new SchemaValidator();
 
-            ProcessingReport r = schemaValidator.validate(schemaPath, jsonString);
+            ProcessingReport r = SchemaValidator.validate(schemaPath, jsonString);
+
             r.forEach(message -> {
                 if( ! (allowAdditional && "\"additionalProperties\"".equals(String.valueOf(message.asJson().get("keyword"))))) {
                     execReport.addError(message.asJson());
@@ -407,6 +408,10 @@ public class ItemValidator {
             log.info("== cause ==");
             log.info(e1.getMessage());
             execReport.addMessage(e1.getMessage());
+            return execReport;
+        } catch (CollectionNotFound e2) {
+            log.info("Collection not found");
+            execReport.addMessage(e2.getMessage());
             return execReport;
         }
 
@@ -481,11 +486,11 @@ public class ItemValidator {
         try {
         	boolean passed = false;
         	if(statusCode == 200) {
-        		testReports.add(schemaMatch(validatableResponse, "/schemas" + schemaPath + ".json", allowAdditional));
+        		testReports.add(schemaMatch(validatableResponse, "schemas" + schemaPath + ".json", allowAdditional));
         		passed = true;
         	}else if(statusCode == 202) {
         		testReports.add(saveVariable(validatableResponse, variables, "/result/searchResultsDbId", searchResultVariableName));
-        		testReports.add(schemaMatch(validatableResponse, "/schemas" + schemaPath + "202.json", allowAdditional));
+        		testReports.add(schemaMatch(validatableResponse, "schemas" + schemaPath + "202.json", allowAdditional));
         		passed = true;
         	}
 

--- a/brava-app/core/src/main/java/org/brapi/brava/core/validation/SchemaValidator.java
+++ b/brava-app/core/src/main/java/org/brapi/brava/core/validation/SchemaValidator.java
@@ -1,14 +1,19 @@
 package org.brapi.brava.core.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jackson.JsonNodeReader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import org.brapi.brava.core.exceptions.CollectionNotFound;
+import org.brapi.brava.core.model.Collection;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.Charset;
 
 /**
@@ -16,12 +21,9 @@ import java.nio.charset.Charset;
  */
 public class SchemaValidator {
 
-    private JsonSchemaFactory validator;
+    private static final JsonSchemaFactory validator = JsonSchemaFactory.byDefault();
     private static final JsonNodeReader NODE_READER = new JsonNodeReader();
-
-    public SchemaValidator() {
-        this.validator = JsonSchemaFactory.byDefault();
-    }
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     /**
      * Validate an instance with a schema
@@ -32,12 +34,21 @@ public class SchemaValidator {
      * @throws IOException         Thrown when reading the schema is not possible.
      * @throws ProcessingException Thrown when validating the instance.
      */
-    public ProcessingReport validate(String path, String instanceString) throws ProcessingException, IOException {
+    public static ProcessingReport validate(String path, String instanceString) throws ProcessingException, IOException, CollectionNotFound {
 
         JsonNode instance = NODE_READER.fromInputStream(new ByteArrayInputStream(instanceString.getBytes(Charset.defaultCharset())));
-        final JsonSchema schemaNode = validator.getJsonSchema(path);
 
-        return schemaNode.validateUnchecked(instance, true); //Unchecked, deepCheck
+        InputStream resource = SchemaValidator.class.getClassLoader().getResourceAsStream(path);
+
+        if (resource != null) {
+            final JsonSchema schemaNode = validator.getJsonSchema(mapper.readTree(resource));
+
+            return schemaNode.validateUnchecked(instance, true);
+            //Unchecked, deepCheck
+        }
+        else {
+            throw new CollectionNotFound("No resource found with path: " + path);
+        }
     }
 
 }

--- a/brava-app/core/src/test/java/org/brapi/brava/core/validation/SchemaValidatorTest.java
+++ b/brava-app/core/src/test/java/org/brapi/brava/core/validation/SchemaValidatorTest.java
@@ -1,6 +1,7 @@
 package org.brapi.brava.core.validation;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import org.brapi.brava.core.exceptions.CollectionNotFound;
 
 import java.io.IOException;
 import java.net.URI;
@@ -14,15 +15,14 @@ class SchemaValidatorTest {
 
     //@Test
     void validate() {
-        SchemaValidator schemaValidator = new SchemaValidator() ;
 
         URI uri = null;
         try {
             uri = ClassLoader.getSystemResource("response/v1/metadata.json").toURI();
             String json = Files.readString(Paths.get(uri));
 
-            schemaValidator.validate("schemas/v1/metadata.json", json) ;
-        } catch (URISyntaxException | IOException | ProcessingException e) {
+            SchemaValidator.validate("schemas/v1/metadata.json", json) ;
+        } catch (URISyntaxException | IOException | ProcessingException | CollectionNotFound e) {
             e.printStackTrace();
 
             fail(e.getMessage()) ;

--- a/brava-app/web/build.gradle
+++ b/brava-app/web/build.gradle
@@ -11,3 +11,11 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/* Used to expose a port for debugging backend
+tasks.named("bootRun") {
+    jvmArgs = [
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+    ]
+}
+*/


### PR DESCRIPTION
While trying to build and run the validator locally and run tests, I was finding errors related to the fact that my machine does not path the resources required the same way as the machines this app was originally developed on.

I have updated the code to use `class.getClassLoader().getResourceAsStream(path)` so that the resources files can be loaded on any machine regardless of pathing.

I also added a way to add a debug port via a comment.  By default it is commented out.